### PR TITLE
ConfigureFreedns update

### DIFF
--- a/ConfigureFreedns.sh
+++ b/ConfigureFreedns.sh
@@ -1,20 +1,135 @@
 #!/bin/bash
+
 if [ "`id -u`" != "0" ]
 then
-echo "Script needs root - execute bootstrap.sh or use sudo bash installation.sh"
-echo "Cannot continue.."
+echo "Script needs root - use sudo bash ConfigureFreedns.sh"
+echo "Cannot continue."
 exit 5
 fi
 
 sudo apt-get install bind9-dnsutils -y
 
 echo
-echo "Move to use free dns instead of noip.com"
+echo "Move to use free dns instead of noip.com" - tzachi-dar
 echo
 
-read -rep "Please enter host name (for example mynightscoute.mooo.com) "$'\n'"hostname: " hostname
-read -rep "please enter direct url. Should look like https://freedns.afraid.org/dynamic/update.php?d005WVNjWkE3aDhyWkJpa1h1cFZiOUV5OjIwNzQ4NTY1 "$'\n'" direct_url: " directurl
+got_them=0
+while [ $got_them -lt 1 ]
+do
+go_back=0
+clear
+exec 3>&1
+Values=$(dialog --colors --ok-label "Submit" --form "     \Zr Developed by the xDrip team \Zn\n\n\n\
+Enter your FreeDNS userID and password." 12 50 0 "User ID:" 1 1 "$user" 1 14 25 0 "Password:" 2 1 "$pass" 2 14 25 0 2>&1 1>&3)
+response=$?
+if [ $response = 255 ] || [ $response = 1 ] # cancled or escaped
+then
+clear
+exit 5
+fi
 
+exec 3>&-
+user=$(echo "$Values" | sed -n 1p)
+pass=$(echo "$Values" | sed -n 2p)
+
+if [ "$user" = "" ] || [ "$pass" = "" ] #  At least one parameter is blank. 
+then
+  go_back=1
+  clear
+  dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\
+  You need to enter both userID and password.  Try again."  8 50
+fi
+clear
+
+if [ $go_back -lt 1 ] # if 7
+then
+  arg1="https://freedns.afraid.org/api/?action=getdyndns&v=2&sha="
+  arg2=$(echo -n "$user|$pass" | sha1sum | awk '{print $1;}')
+  arg="$arg1$arg2"
+
+  wget -O /tmp/hosts "$arg"
+if [ ! "`grep 'Could not authenticate' /tmp/hosts`" = "" ] # Failed to log in
+then
+  dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\n\
+  Failed to authenticate.  Try again."  8 50
+  go_back=1
+fi
+
+if [ $go_back -lt 1 ] # if 6
+then
+  Lines=$(awk 'END{print NR}' /tmp/hosts)
+  if [ $Lines -eq 0 ] # No hostnames # if 5
+  then
+    dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\
+    No subdomains found.  Ensure you have one in your Free DNS account, and try again."  9 50
+    go_back=1
+
+  elif [ $Lines -gt 1 ] # More than one hostname
+  then
+    clear
+    exec 3>&1
+    subvalue=$(dialog --colors --ok-label "Submit" --form "     \Zr Developed by the xDrip team \Zn\n\n\n\
+    You have more than one subdomain.  Enter the subdomain you want to use. \n\
+    It should look like mine.strangled.net"  12 50 0 "Subdomain:" 1 1 "$subd" 1 14 25 0 2>&1 1>&3)
+    response2=$?
+    if [ $response2 = 255 ] || [ $response2 = 1 ] # canceled or escaped
+    then
+      go_back=1
+    fi
+
+    exec 3>&-
+    subd=$(echo "$subvalue" | sed -n 1p)
+    if [ $go_back -lt 1 ] # if 4
+    then
+      if [ "$subd" = "" ] # Nothing entered
+      then
+        go_back=1
+        clear
+        dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\n\
+        You need to enter a subdomain.  Try again."  8 50
+      fi
+
+      if [ $go_back -lt 1 ] # if 3
+      then
+        grep $subd /tmp/hosts > /tmp/FullLine # Find the lines that match and put them in FullLine.
+        if [ ! -s /tmp/FullLine ] # Not found
+        then
+          go_back=1
+          dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\n\
+          The subdomain you entered is not one of the ones we found.  Try again." 9 50
+        fi
+        if [ $go_back -lt 1 ]  # if 2
+        then
+        Lines2=$(wc -l < /tmp/FullLine)
+        if [ $Lines2 -gt 1 ] # More than one found  if 1
+        then
+          go_back=1
+          dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\n\
+          The value you entered matches more than one of your subdomains.  Try again and enter a unique value." 11 50
+        else
+          FLine=$(</tmp/FullLine)
+          got_them=1 # We have the hostname and direct URL
+        fi # fi 1
+
+      fi # fi 2
+      fi # fi 3
+    fi # fi 4
+  else
+    cp /tmp/hosts /tmp/FullLine
+    FLine=$(</tmp/FullLine)
+    got_them=1 # We have the hostname and direct URL
+  fi # fi 5
+
+fi # fi 6
+fi # fi 7
+
+done
+clear
+
+IFS='|'
+read -a split <<< $FLine
+hostname=${split[0]}
+directurl=${split[2]}
 
 #create a file to store the data for the startup script.
 cat> /etc/free-dns.sh<<EOF
@@ -34,13 +149,31 @@ fi
 
 # wait for the ip to be updated. This might take up to 10 minutes.
 
+cnt=0
 while : ; do
     sleep 30
     registered=$(nslookup $hostname|tail -n2|grep A|sed s/[^0-9.]//g)
     current=$(wget -q -O - http://checkip.dyndns.org|sed s/[^0-9.]//g)
     echo $current $registered
     [[ "$registered" != "$current" ]] || break
+    cnt=$((cnt+1))
+    echo $cnt
+    if (( cnt%6 == 0 )); then
+         echo "ccc" $cnt
+        wget -O - --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 $directurl
+    fi
+    sudo systemd-resolve --flush-caches
+    ping -c 1 $hostname
+    sudo systemd-resolve -4 $hostname
+    if [ $cnt -gt 20 ]
+    then
+      clear
+      dialog --colors --msgbox "    \Zr Developed by the xDrip team \Zn\n\n\
+      Please close this window.  Open a new SSH terminal.  Run FreeDNS Setup again to complete FreeDNS setup." 12 50
+      exit
+    fi
 done
 
 #Fix the certificate using the new host name.
 sudo certbot --nginx -d "$hostname" --redirect 
+ 

--- a/menu.sh
+++ b/menu.sh
@@ -11,7 +11,7 @@ Choice=$(dialog --colors --nocancel --nook --menu "\
       \Zr Developed by the xDrip team \Zn\
   \n\n
 Use the arrow keys to move the cursor.\n\
-Press Enter to execute the highlighted option.\n\n" 22 50 11\
+Press Enter to execute the highlighted option.\n\n" 22 50 12\
  "1" "Initial Nightscout install"\
  "2" "noip.com association"\
  "3" "Edit Nightscout Variables"\
@@ -21,8 +21,9 @@ Press Enter to execute the highlighted option.\n\n" 22 50 11\
  "7" "Backup MongoDB"\
  "8" "Restore MongoDB backup"\
  "9" "Status"\
- "10" "Reboot server (Nightscout)"\
- "11" "Exit to shell (terminal)"\
+ "10" "FreeDNS Setup"\
+ "11" "Reboot server (Nightscout)"\
+ "12" "Exit to shell (terminal)"\
  3>&1 1>&2 2>&3)
 
 case $Choice in
@@ -64,6 +65,11 @@ sudo /xDrip/scripts/update_nightscout.sh
 ;;
 
 10)
+clear
+sudo /xDrip/scripts/ConfigureFreedns.sh
+;;
+
+11)
 dialog --yesno "Are you sure you want to reboot the server?\n
 If you do, all unsaved open files will close without saving.\n"  8 50
 response=$?
@@ -75,7 +81,7 @@ sudo reboot
 fi
 ;;
 
-11)
+12)
 cd /tmp
 clear
 dialog --msgbox "You will now exit to the shell (terminal).\n\


### PR DESCRIPTION
Instead of asking user for a direct URL, the user is asked for their userID and password.
Dialogs are used if needed to also ask for the subdomain if more than one subdomain exists.

The menu has been changed to include an option to call ConfigureFreedns.sh.

This change will allow everyone to try FreeDNS while a fresh install still uses noip.com.
So, we are not rushing the migration to FreeDNS.