### PR TITLE
Trying to Fix freedns sometimes failing:

### DIFF
--- a/ConfigureFreedns.sh
+++ b/ConfigureFreedns.sh
@@ -177,14 +177,28 @@ while : ; do
 done
 
 #Fix the certificate using the new host name.
-sudo certbot --nginx -d "$hostname" --redirect --agree-tos --no-eff-email
 
-if [ ! -s /etc/letsencrypt/live/"$hostname"/cert.pem ] || [ ! -s /etc/letsencrypt/live/"$hostname"/privkey.pem ]
-then
-cat > /tmp/FreeDNS_Failed << EOF
+
+for i in {1..4}
+do
+    for j in {1..1000}
+    do
+    read -t 0.001 dummy
+    done
+
+    sudo certbot --nginx -d "$hostname" --redirect --agree-tos --no-eff-email
+
+    if [ ! -s /etc/letsencrypt/live/"$hostname"/cert.pem ] || [ ! -s /etc/letsencrypt/live/"$hostname"/privkey.pem ]
+    then
+
+         echo freedns failed sleeping 
+         sleep 60
+    else
+        # worked, geting out of the loop.
+        exit 1
+    fi
+done cat > /tmp/FreeDNS_Failed << EOF
 Internal error.  Must run FreeDNS again.
 EOF
 
 dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\nInternal error.  Press enter to exit.  Then, run FreeDNS Setup again" 9 50
-fi
- 

--- a/ConfigureFreedns.sh
+++ b/ConfigureFreedns.sh
@@ -183,10 +183,10 @@ for i in {1..4}
 do
     for j in {1..1000}
     do
-    read -t 0.001 dummy
+    read -t 0.001 dummy < /dev/tty
     done
 
-    sudo certbot --nginx -d "$hostname" --redirect --agree-tos --no-eff-email
+    sudo certbot --nginx -d "$hostname" --redirect --agree-tos --no-eff-email < /dev/tty
 
     if [ ! -s /etc/letsencrypt/live/"$hostname"/cert.pem ] || [ ! -s /etc/letsencrypt/live/"$hostname"/privkey.pem ]
     then

--- a/ConfigureFreedns.sh
+++ b/ConfigureFreedns.sh
@@ -195,9 +195,10 @@ do
          sleep 60
     else
         # worked, geting out of the loop.
-        exit 1
+        exit 0
     fi
-done cat > /tmp/FreeDNS_Failed << EOF
+done 
+cat > /tmp/FreeDNS_Failed << EOF
 Internal error.  Must run FreeDNS again.
 EOF
 

--- a/NS_Install2.sh
+++ b/NS_Install2.sh
@@ -120,9 +120,9 @@ echo "Current API secret is: $cs"
 echo
 echo "If you would like to change it please enter the new secret now or hit enter to leave the same"
 
-for loop in 1 2 3 4 5 6 7 8 9
+for j in {1..1000}
 do
-read -t 0.1 dummy
+read -t 0.001 dummy
 done
 read -p "New secret 12 character minimum length (blank to skip change) : " ns
 

--- a/NS_Install2.sh
+++ b/NS_Install2.sh
@@ -122,15 +122,15 @@ echo "If you would like to change it please enter the new secret now or hit ente
 
 for j in {1..1000}
 do
-read -t 0.001 dummy
+read -t 0.001 dummy < /dev/tty
 done
-read -p "New secret 12 character minimum length (blank to skip change) : " ns
+read -p "New secret 12 character minimum length (blank to skip change) : " ns < /dev/tty
 
 if [ "$ns" != "" ]
 then
 while [ ${#ns} -lt 12 ] && [ "$ns" != "" ]
 do
-read -p "Needs to be at least 12 chars - try again: " ns
+read -p "Needs to be at least 12 chars - try again: " ns < /dev/tty
 done
 if [ "$ns" != "" ]
 then

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -41,12 +41,17 @@ if [ ./update_scripts.sh ]
 then
 sudo rm update_scripts.sh
 fi
+rm -fr nightscout-vps
 
 if [ $Test -gt 0 ]
 then
 wget https://raw.githubusercontent.com/Navid200/cgm-remote-monitor/Navid_2022_11_16_Test/update_scripts.sh # Test
 else
 wget https://raw.githubusercontent.com/jamorham/nightscout-vps/vps-1/update_scripts.sh # Main
+git clone https://github.com/jamorham/nightscout-vps.git nightscout-vps
+cd nightscout-vps
+git checkout vps-1
+
 fi
 
 if [ ! -s update_scripts.sh ]


### PR DESCRIPTION
Still under test:

It seems that there have been two issues that we have been dealing with lastly: 1) No prompt for entering API_KEY.
2) Problems with freedns registration.
Both have started lately in the last release, and don't happen all the time. I think that they might be related, here is why.
I think that for some reason, asking for 10 reads is for some reason not enough to take us behind the pipelined input, so we might need to increase this. (for example to 1000) This might also affect one running freedns, as the freedns is asking for email, and won't work without it.

tzachi-dar @tzachi-dar 11:17
The freedns might also fail because the network data is still not propagated. We are telling people to run things again. So, I'm saying, why don't we run it again for them. That is after a failure in freedns, try to wait a minute and run it again.