### PR TITLE
Fix freedns2

### DIFF
--- a/ConfigureFreedns.sh
+++ b/ConfigureFreedns.sh
@@ -177,14 +177,29 @@ while : ; do
 done
 
 #Fix the certificate using the new host name.
-sudo certbot --nginx -d "$hostname" --redirect --agree-tos --no-eff-email
 
-if [ ! -s /etc/letsencrypt/live/"$hostname"/cert.pem ] || [ ! -s /etc/letsencrypt/live/"$hostname"/privkey.pem ]
-then
+
+for i in {1..4}
+do
+    for j in {1..1000}
+    do
+    read -t 0.001 dummy
+    done
+
+    sudo certbot --nginx -d "$hostname" --redirect --agree-tos --no-eff-email
+
+    if [ ! -s /etc/letsencrypt/live/"$hostname"/cert.pem ] || [ ! -s /etc/letsencrypt/live/"$hostname"/privkey.pem ]
+    then
+
+         echo freedns failed sleeping 
+         sleep 60
+    else
+        # worked, geting out of the loop.
+        exit 1
+    fi
+done
 cat > /tmp/FreeDNS_Failed << EOF
 Internal error.  Must run FreeDNS again.
 EOF
 
 dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\nInternal error.  Press enter to exit.  Then, run FreeDNS Setup again" 9 50
-fi
- 

--- a/NS_Install2.sh
+++ b/NS_Install2.sh
@@ -120,9 +120,9 @@ echo "Current API secret is: $cs"
 echo
 echo "If you would like to change it please enter the new secret now or hit enter to leave the same"
 
-for loop in 1 2 3 4 5 6 7 8 9
+for j in {1..1000}
 do
-read -t 0.1 dummy
+read -t 0.001 dummy
 done
 read -p "New secret 12 character minimum length (blank to skip change) : " ns
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -41,12 +41,16 @@ if [ ./update_scripts.sh ]
 then
 sudo rm update_scripts.sh
 fi
+rm -fr nightscout-vps
 
 if [ $Test -gt 0 ]
 then
 wget https://raw.githubusercontent.com/Navid200/cgm-remote-monitor/Navid_2022_11_16_Test/update_scripts.sh # Test
 else
-wget https://raw.githubusercontent.com/jamorham/nightscout-vps/vps-1/update_scripts.sh # Main
+git clone https://github.com/jamorham/nightscout-vps.git nightscout-vps
+cd nightscout-vps
+git checkout vps-1
+
 fi
 
 if [ ! -s update_scripts.sh ]

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -97,5 +97,5 @@ Please take a note, delete the virtual machine, and create a new one.   For more
 # Bring up the status page
 /xDrip/scripts/Status.sh
 clear
-/xDrip/scripts/menu.sh
+/xDrip/scripts/menu.sh < /dev/tty
  


### PR DESCRIPTION
This PR is doing the following:

use "menu.sh< /dev/tty" in order to allow the reads to work even when they are running from the bootstrap file.
In the case of a failure in certbot, try 4 times in order to overcome momentary network failures.
use git clone instead of wget in order to have a uniform way of getting installation files.