### PR TITLE
Test method

### DIFF
--- a/NS_Install.sh
+++ b/NS_Install.sh
@@ -12,9 +12,6 @@ echo "Cannot continue.."
 exit 5
 fi
 
-Test=0
-#Test=1 ################ This line must be commented out before submitting a PR.  ##########################
-
 clear
 dialog --colors --msgbox "      \Zr Developed by the xDrip team \Zn\n\n\
 Some required packages will be installed now.  It will take about 15 minutes to complete.  This terminal needs to be kept open.  Press enter to proceed.\n\n\
@@ -61,20 +58,9 @@ sudo apt -y autoremove
 cd /srv
 
 echo "Installing Nightscout"
-
-if [ $Test -lt 1 ] # We are not testing.
-then
-
-sudo git clone https://github.com/jamorham/nightscout-vps.git
-cd nightscout-vps
-sudo git checkout vps-1
-else # We are testing.
-
-sudo git clone https://github.com/Navid200/cgm-remote-monitor.git
-cd cgm-remote-monitor
-sudo git checkout Navid_2022_11_16_Test
-fi
-sudo git pull
+cd "$(< repo)" 
+sudo git reset --hard  # delete any local edits.
+sudo git pull  # Update database from remote.
 
 sudo npm install
 sudo npm run generate-keys

--- a/NS_Install2.sh
+++ b/NS_Install2.sh
@@ -12,9 +12,6 @@ You need to complete installation phase 1 first." 9 50
 exit
 fi
 
-Test=0
-#Test=1 ########################## This line must be commented out before submitting a PR. ###################
-
 if [ "`id -u`" != "0" ]
 then
 echo "Script needs root - use sudo bash NS_Install2.sh"
@@ -38,7 +35,6 @@ echo "Nginx config already patched"
 fi
 
 sudo service nginx start
-# sudo certbot --nginx -d "$hostname" --redirect  # We are doing this in ConfigureFreedns.sh
 
 sudo systemctl daemon-reload
 sudo systemctl start mongodb
@@ -62,9 +58,6 @@ EOF
 
 fi
 
-if [ $Test -lt 1 ] # If we are not testing.
-then
-
 cat > /etc/nightscout-start.sh << "EOF"
 #!/bin/sh
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -74,7 +67,8 @@ export MONGO_CONNECTION="mongodb://username:password@localhost:27017/Nightscout"
 export INSECURE_USE_HTTP=true
 export HOSTNAME="127.0.0.1"
 export PORT="1337"
-cd /srv/nightscout-vps
+cd /srv
+cd "$(< repo)" 
 while [ "`netstat -lnt | grep 27017 | grep -v grep`" = "" ]
 do
 echo "Waiting for mongo to start"
@@ -87,32 +81,6 @@ node server.js
 sleep 30
 done
 EOF
-
-else # We are testing.
-cat > /etc/nightscout-start.sh << "EOF"
-#!/bin/sh
-export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-. /etc/nsconfig
-export MONGO_COLLECTION="entries"
-export MONGO_CONNECTION="mongodb://username:password@localhost:27017/Nightscout"
-export INSECURE_USE_HTTP=true
-export HOSTNAME="127.0.0.1"
-export PORT="1337"
-cd /srv/cgm-remote-monitor
-while [ "`netstat -lnt | grep 27017 | grep -v grep`" = "" ]
-do
-echo "Waiting for mongo to start"
-sleep 5
-done
-sleep 5
-while [ 1 ]
-do
-node server.js
-sleep 30
-done
-EOF
-
-fi
 
 cs=`grep 'API_SECRET=' /etc/nsconfig | head -1 | cut -f2 -d'"'`
 

--- a/Status.sh
+++ b/Status.sh
@@ -64,22 +64,40 @@ then
 http="\Zb\Z1Closed\Zn"
 fi
 
-
 mongo="$(mongod --version | sed -n 1p)"
 ns="$(ps -ef | grep SCREEN | grep root | fold --width=40 | sed -n 1p)"
 
+uname="\Zb\Z2$(< /srv/username)\Zn"
+if [ ! "$uname" = "jamorham" ]
+then
+uname="\Zb\Z1$(< /srv/username)\Zn"
+fi
+
+repo="\Zb\Z2$(< /srv/repo)\Zn"
+if [ ! "$repo" = "nightscout-vps" ]
+then
+repo="\Zb\Z1$(< /srv/repo)\Zn"
+fi
+
+branch="\Zb\Z2$(< /srv/brnch)\Zn"
+if [ ! "$branch" = "vps-1" ]
+then
+branch="\Zb\Z1$(< /srv/brnch)\Zn"
+fi
+
+
 dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
                 \Zb Status \Zn\n\n\
-  \ZbVirtual Machine\Zn\n\
 Zone: "$Zone" \n\
 RAM: $Ramsize \n\
 Disk type: "$disk" \n\
 Disk size: $disksz        $DiskUsedPercent used \n\
 Ubuntu: $ubuntu \n\
-HTTP & HTTPS:  $http \n\n\
+HTTP & HTTPS:  $http \n\
 ------------------------------------------ \n\
+/$uname/$repo/$branch\n\
 Swap: $swap \n\
 Mongo: $mongo \n\
 NS proc: $ns \n\
- " 21 50
+ " 22 50
  

--- a/Status.sh
+++ b/Status.sh
@@ -67,20 +67,20 @@ fi
 mongo="$(mongod --version | sed -n 1p)"
 ns="$(ps -ef | grep SCREEN | grep root | fold --width=40 | sed -n 1p)"
 
-uname="\Zb\Z2$(< /srv/username)\Zn"
-if [ ! "$uname" = "jamorham" ]
+uname="$(< /srv/username)"
+if [ ! "$(< /srv/username)" = "jamorham" ]
 then
 uname="\Zb\Z1$(< /srv/username)\Zn"
 fi
 
-repo="\Zb\Z2$(< /srv/repo)\Zn"
-if [ ! "$repo" = "nightscout-vps" ]
+repo="$(< /srv/repo)"
+if [ ! "$(< /srv/repo)" = "nightscout-vps" ]
 then
 repo="\Zb\Z1$(< /srv/repo)\Zn"
 fi
 
-branch="\Zb\Z2$(< /srv/brnch)\Zn"
-if [ ! "$branch" = "vps-1" ]
+branch="$(< /srv/brnch)"
+if [ ! "$(< /srv/brnch)" = "vps-1" ]
 then
 branch="\Zb\Z1$(< /srv/brnch)\Zn"
 fi

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,14 +1,24 @@
 #!/bin/bash
 PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin"
-
-Test=0
-# Uncomment the following line for testing.
-#Test=1 ###################################### This line must be commented out before submitting a PR.  ##########################################
-# curl https://raw.githubusercontent.com/Navid200/cgm-remote-monitor/Navid_2022_11_16_Test/bootstrap.sh | bash  <---  Only tested this way
+# curl https://raw.githubusercontent.com/Navid200/cgm-remote-monitor/TestMethod/bootstrap.sh | bash
 
 echo 
-echo "Bootstrapping the menu - Navid200"
+echo "Bootstrapping the installation files - Navid200"
 echo
+
+if [ ! -z "$(ls /srv)" ]
+then
+clear
+dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\
+The script you are running, \"bootstrap\", is meant to initiate an installtion.  However, the file system does not seem to be empty.\n\n\
+If you already have an installtion on this machine and proceed by pressing enter, it will be modified.  If that's not your intention, please press escape to abort." 15 50
+if [ $? -eq 255 ]
+then
+clear
+exit
+fi
+fi
+clear
 
 sudo apt-get update
 sudo apt-get install dialog
@@ -26,32 +36,33 @@ sudo apt-get install -y  git python gcc g++ make
 sudo apt-get -y install netcat
 
 cd /
-if [ ! -s xDrip ] # Create the xDrip directory if it does not exist.
-then
+sudo rm -rf xDrip
 sudo mkdir xDrip
-fi
 cd xDrip
-if [ ! -s scripts ]
-then
 sudo mkdir scripts
-fi
 
-cd /tmp
-if [ ./update_scripts.sh ]
-then
-sudo rm update_scripts.sh
-fi
-rm -fr nightscout-vps
+cd /srv
+sudo rm -rf *
+#sudo git clone https://github.com/jamorham/nightscout-vps.git  # ✅✅✅✅✅ Main - Uncomment before PR.
+sudo git clone https://github.com/Navid200/cgm-remote-monitor.git  # ⛔⛔⛔⛔⛔ For test - Comment out before PR.
 
-if [ $Test -gt 0 ]
-then
-wget https://raw.githubusercontent.com/Navid200/cgm-remote-monitor/Navid_2022_11_16_Test/update_scripts.sh # Test
-else
-git clone https://github.com/jamorham/nightscout-vps.git nightscout-vps
-cd nightscout-vps
-git checkout vps-1
+ls > /tmp/repo
+sudo mv -f /tmp/repo .    # The repository name is now in /srv/repo
+cd "$(< repo)"
+#sudo git checkout vps-1  # ✅✅✅✅✅ Main - Uncomment before PR.
+sudo git checkout TestMethod  # ⛔⛔⛔⛔⛔ For test - Comment out before PR.
 
-fi
+sudo git branch > /tmp/branch
+grep "*" /tmp/branch | awk '{print $2}' > /tmp/brnch
+sudo mv -f /tmp/brnch ../.  # The branch name is now in /srv/brnch
+
+sudo git remote -v > /tmp/username
+grep "fetch" /tmp/username | awk '{print $2}' >/tmp/username2
+FLine=$(</tmp/username2)
+IFS='/'
+read -a split <<< $FLine
+echo ${split[3]} > /tmp/username 
+sudo mv -f /tmp/username ../.
 
 if [ ! -s update_scripts.sh ]
 then
@@ -59,8 +70,8 @@ echo "UNABLE TO DOWNLOAD update_scripts SCRIPT! - cannot continue - please try a
 exit 5
 fi
 
-sudo chmod 755 update_scripts.sh
-sudo mv -f update_scripts.sh /xDrip/scripts
+sudo chmod 755 *.sh
+sudo cp -f update_scripts.sh /xDrip/scripts
 
 # Updating the scripts
 cat > /tmp/nodialog_update_scripts << EOF
@@ -98,4 +109,4 @@ Please take a note, delete the virtual machine, and create a new one.   For more
 /xDrip/scripts/Status.sh
 clear
 /xDrip/scripts/menu.sh < /dev/tty
- 
+  

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -43,14 +43,14 @@ sudo mkdir scripts
 
 cd /srv
 sudo rm -rf *
-#sudo git clone https://github.com/jamorham/nightscout-vps.git  # ✅✅✅✅✅ Main - Uncomment before PR.
-sudo git clone https://github.com/Navid200/cgm-remote-monitor.git  # ⛔⛔⛔⛔⛔ For test - Comment out before PR.
+sudo git clone https://github.com/jamorham/nightscout-vps.git  # ✅✅✅✅✅ Main - Uncomment before PR.
+#sudo git clone https://github.com/Navid200/cgm-remote-monitor.git  # ⛔⛔⛔⛔⛔ For test - Comment out before PR.
 
 ls > /tmp/repo
 sudo mv -f /tmp/repo .    # The repository name is now in /srv/repo
 cd "$(< repo)"
-#sudo git checkout vps-1  # ✅✅✅✅✅ Main - Uncomment before PR.
-sudo git checkout TestMethod  # ⛔⛔⛔⛔⛔ For test - Comment out before PR.
+sudo git checkout vps-1  # ✅✅✅✅✅ Main - Uncomment before PR.
+#sudo git checkout TestMethod  # ⛔⛔⛔⛔⛔ For test - Comment out before PR.
 
 sudo git branch > /tmp/branch
 grep "*" /tmp/branch | awk '{print $2}' > /tmp/brnch

--- a/menu.sh
+++ b/menu.sh
@@ -56,6 +56,12 @@ sudo /xDrip/scripts/clone_nightscout.sh
 ;;
 
 7)
+cd /srv
+cd "$(< repo)"  # Go to the local database
+sudo git reset --hard  # delete any local edits.
+sudo git pull  # Update database from remote.
+sudo chmod 755 update_scripts.sh
+sudo cp -f update_scripts.sh /xDrip/scripts/.
 clear
 sudo /xDrip/scripts/update_scripts.sh
 ;;

--- a/update_scripts.sh
+++ b/update_scripts.sh
@@ -8,6 +8,25 @@ echo
 echo "Fetch the latest scripts from GitHub - Navid200"
 echo
 
+if [ ! -s /srv/repo ]  # Create the file containing the repository name if nonexistent.
+then
+cat > /srv/repo << EOF
+nightscout-vps
+EOF
+fi
+if [ ! -s /srv/brnch ]  # Create the file containing the branch name if nonexistent.
+then
+cat > /srv/brnch << EOF
+vps-1
+EOF
+fi
+if [ ! -s /srv/username ]  # Create the file containing the user name if nonexistent.
+then
+cat > /srv/username << EOF
+jamorham
+EOF
+fi
+
 cd /srv
 cd "$(< repo)" 
 sudo git reset --hard  # delete any local edits.

--- a/update_scripts.sh
+++ b/update_scripts.sh
@@ -14,9 +14,9 @@ sudo git reset --hard  # delete any local edits.
 sudo git pull  # Update database from remote.
 
 sudo chmod 755 *.sh # Change premissions to allow execution by all.
-rm -f /xDrip/scripts/*.sh # Remove the existing sh files
+sudo rm -f /xDrip/scripts/*.sh # Remove the existing sh files
 sudo cp *.sh /xDrip/scripts # Overwrite the scripts in the scripts directory with the new ones.
-rm -rf /xDrip/ConfigServer # Remove the existing ConfigServer directory
+sudo rm -rf /xDrip/ConfigServer # Remove the existing ConfigServer directory
 sudo cp -r ConfigServer /xDrip/.
 cd ..
 

--- a/update_scripts.sh
+++ b/update_scripts.sh
@@ -1,46 +1,24 @@
 #!/bin/bash
 
+# This should never be called before first being updated to the latest remote release.
+# Currently, only bootstrap and menu call this.  Both update this file before calling it.
+# If you decide to call this anywhere else, make sure to update the local copy before calling it.
+
 echo
 echo "Fetch the latest scripts from GitHub - Navid200"
 echo
 
-Test=0
-# Comment out the next line before submission.
-#Test=1 ########################### This line must be commented out before submitting a PR #########
+cd /srv
+cd "$(< repo)" 
+sudo git reset --hard  # delete any local edits.
+sudo git pull  # Update database from remote.
 
-cd /tmp
-
-if [ $Test -gt 0 ] # Are we testing?  
-then
-if [ -s ./cgm-remote-monitor ]
-then
-sudo rm -r cgm-remote-monitor
-fi
-sudo git clone https://github.com/Navid200/cgm-remote-monitor.git # Test
-cd cgm-remote-monitor
-sudo git checkout Navid_2022_11_16_Test
-else # If we are not testing
-if [ -s ./nightscout-vps ]
-then
-sudo rm -r nightscout-vps
-fi
-sudo git clone https://github.com/jamorham/nightscout-vps.git #  Main
-cd nightscout-vps
-sudo git checkout vps-1
-fi
-
-sudo git pull
 sudo chmod 755 *.sh # Change premissions to allow execution by all.
 rm -f /xDrip/scripts/*.sh # Remove the existing sh files
-sudo mv -f *.sh /xDrip/scripts # Overwrite the scripts in the scripts directory with the new ones.
+sudo cp *.sh /xDrip/scripts # Overwrite the scripts in the scripts directory with the new ones.
 rm -rf /xDrip/ConfigServer # Remove the existing ConfigServer directory
-sudo mv ConfigServer /xDrip/.
+sudo cp -r ConfigServer /xDrip/.
 cd ..
-sudo rm -rf nightscout-vps 
-sudo rm -rf cgm-remote-monitor
-
-# Update Configserver
-
 
 if [ ! -s /tmp/nodialog_update_scripts ]
 then


### PR DESCRIPTION
This PR has two objectives.  The first is to clean-up the way I handled testing before submitting a PR.  This is explained first.  The user will experience nothing from this change.
The second is to allow the update_script utility to take effect as soon as the user uses it even if the update_scripts utility itself has been changed.  This is explained at the bottom.  The user will see the impact the next time a developer edits the update_scripts utility.
<br/>  
  
---  
  
Only bootstrap clones the repository into a local directory.
It saves the username, repository name, and branch name into identified files in the /srv directory.
The installation script uses the local repository that bootstrap clones.
The same with the update_scripts script.  It only runs git pull to update the files.  But, it does not run another clone command.

All files use the same directory to access files.  The files find the name of the directory from the saved content by the bootstrap.

The result is that all the if statements are gone.
The only file that still contains lines that need to be changed before PR is the bootstrap file.  Please see this screenshot: 

![Screenshot 2022-11-25 213826](https://user-images.githubusercontent.com/51497406/204069366-a2b3caec-096b-4cf8-a997-31f0ea8f53f4.png)
<br/>  
  
Please don't merge a PR if either of the lines with red markers is still uncommented, or if either of the two lines with green markers is still commented out.  

Those are the only lines (4) that need to be modified before opening a PR.

The repository username, name and branch name are now shown on the status page.
Either of those 3 that does not match Jon's repository is highlighted in red on the status page.  I created a fork intentionally to have a combination to show that the three items could have different colors as shown below.
![Screenshot 2022-11-24 225335](https://user-images.githubusercontent.com/51497406/203901597-5c087e7f-1b04-45d4-b7dc-3fc16da6cd08.png)

<br/>  
<br/>  
  
---  
  
This is a different matter that this same PR is addressing:  

The menu script has been modified so that it updates update_scripts.sh before calling it.
This ensures that if there is ever a change to the update_scripts file, the user can update their system by running update scripts from the main menu only once.  Without this PR, if we ever make a change to the update_scripts.sh file, the users will need to run it twice in sequence to completely update their systems.