### PR TITLE
Do not accept uppercase letters in FreeDNS subdomain

### DIFF
--- a/ConfigureFreedns.sh
+++ b/ConfigureFreedns.sh
@@ -129,6 +129,12 @@ clear
 IFS='|'
 read -a split <<< $FLine
 hostname=${split[0]}
+if [[ "$hostname" =~ [A-Z] ]]
+then
+dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\
+The subdomain should not contain uppercase letters.  Press enter to return to the main menu.  You can rerun FreeDNS Setup when you have a subdomain with no uppercase letters." 10 50
+exit
+fi
 directurl=${split[2]}
 
 #create a file to store the data for the startup script.
@@ -203,3 +209,4 @@ Internal error.  Must run FreeDNS again.
 EOF
 
 dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\nInternal error.  Press enter to exit.  Then, run FreeDNS Setup again" 9 50
+ 


### PR DESCRIPTION
If uppercase letters appear in the submitted subdomain, the user will see the following dialog.
![Screenshot 2022-11-25 220528](https://user-images.githubusercontent.com/51497406/204070459-31da9c33-1f00-4031-9dc1-41e78b15338a.png)

After either pressing enter or escape, the script will end (exit) returning the user to the main menu.

This has been tested both with uppercase to see it exit and with no uppercase to ensure that it will work as before.

@tzachi-dar informed me that uppercase letters should be excluded and asked for this to be added.