### PR TITLE
Lowercase username for FreeDNS

### DIFF
--- a/ConfigureFreedns.sh
+++ b/ConfigureFreedns.sh
@@ -43,8 +43,12 @@ clear
 
 if [ $go_back -lt 1 ] # if 7
 then
+  # As per the FreeDNS api (https://freedns.afraid.org/api/),
+  # the username must be lowercase.
+  user_lowercase=$(echo "$user" | awk '{print tolower($0)}')
+
   arg1="https://freedns.afraid.org/api/?action=getdyndns&v=2&sha="
-  arg2=$(echo -n "$user|$pass" | sha1sum | awk '{print $1;}')
+  arg2=$(echo -n "$user_lowercase|$pass" | sha1sum | awk '{print $1;}')
   arg="$arg1$arg2"
 
   wget -O /tmp/hosts "$arg"


### PR DESCRIPTION
As per the FreeDNS [API](https://freedns.afraid.org/api/), usernames must be lowercase before determining the SHA string. As such, this PR converts the username to lowercase first.

Login Screen (username contains uppercase letter):
<img width="640" alt="Login" src="https://user-images.githubusercontent.com/1320751/204432627-5ca14586-edb9-441d-81b5-4ff057d1b544.png">

Current Behavior:
<img width="640" alt="Previous" src="https://user-images.githubusercontent.com/1320751/204432628-61db8033-9ecb-4f7b-80b8-69f912cd838a.png">

Succeeds with proposed change:
<img width="640" alt="Proposed" src="https://user-images.githubusercontent.com/1320751/204432629-927e6928-1519-4a94-a302-29e36b152362.png">

I tested by uploading the modified file to the home directory of my existing instance and ran it from there. I did not start an entirely new setup via Google Cloud.