### PR TITLE
FreeDNS user ID capital letter dialog

### DIFF
--- a/ConfigureFreedns.sh
+++ b/ConfigureFreedns.sh
@@ -32,6 +32,17 @@ exec 3>&-
 user=$(echo "$Values" | sed -n 1p)
 pass=$(echo "$Values" | sed -n 2p)
 
+if [[ "$user" =~ [A-Z] ]]
+then
+dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\
+Your FreeDNS user ID does not contain uppercase letters.  Even though FreeDNS does not inform you, it converts all uppercase letters to lowercase in your user ID.\n\n\
+If you log into FreeDNS and go to the main menu, you can see your approved user ID at the top in the right pane.\n\n\
+Please try again." 16 50
+go_back=1
+fi
+
+if [ $go_back -lt 1 ] # if 8
+then
 if [ "$user" = "" ] || [ "$pass" = "" ] #  At least one parameter is blank. 
 then
   go_back=1
@@ -50,8 +61,7 @@ then
   wget -O /tmp/hosts "$arg"
 if [ ! "`grep 'Could not authenticate' /tmp/hosts`" = "" ] # Failed to log in
 then
-  dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\n\
-  Failed to authenticate.  Try again."  8 50
+  dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\nFailed to authenticate.  Try again."  8 50
   go_back=1
 fi
 
@@ -60,17 +70,14 @@ then
   Lines=$(awk 'END{print NR}' /tmp/hosts)
   if [ $Lines -eq 0 ] # No hostnames # if 5
   then
-    dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\
-    No subdomains found.  Ensure you have one in your Free DNS account, and try again."  9 50
+    dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\nNo subdomains found.  Ensure you have one in your Free DNS account, and try again."  9 50
     go_back=1
 
   elif [ $Lines -gt 1 ] # More than one hostname
   then
     clear
     exec 3>&1
-    subvalue=$(dialog --colors --ok-label "Submit" --form "     \Zr Developed by the xDrip team \Zn\n\n\n\
-    You have more than one subdomain.  Enter the subdomain you want to use. \n\
-    It should look like mine.strangled.net"  12 50 0 "Subdomain:" 1 1 "$subd" 1 14 25 0 2>&1 1>&3)
+    subvalue=$(dialog --colors --ok-label "Submit" --form "     \Zr Developed by the xDrip team \Zn\n\n\nYou have more than one subdomain.  Enter the subdomain you want to use. \nIt should look like mine.strangled.net"  12 50 0 "Subdomain:" 1 1 "$subd" 1 14 25 0 2>&1 1>&3)
     response2=$?
     if [ $response2 = 255 ] || [ $response2 = 1 ] # canceled or escaped
     then
@@ -85,8 +92,7 @@ then
       then
         go_back=1
         clear
-        dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\n\
-        You need to enter a subdomain.  Try again."  8 50
+        dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\nYou need to enter a subdomain.  Try again."  8 50
       fi
 
       if [ $go_back -lt 1 ] # if 3
@@ -95,8 +101,7 @@ then
         if [ ! -s /tmp/FullLine ] # Not found
         then
           go_back=1
-          dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\n\
-          The subdomain you entered is not one of the ones we found.  Try again." 9 50
+          dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\nThe subdomain you entered is not one of the ones we found.  Try again." 9 50
         fi
         if [ $go_back -lt 1 ]  # if 2
         then
@@ -104,8 +109,7 @@ then
         if [ $Lines2 -gt 1 ] # More than one found  if 1
         then
           go_back=1
-          dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\n\
-          The value you entered matches more than one of your subdomains.  Try again and enter a unique value." 11 50
+          dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\nThe value you entered matches more than one of your subdomains.  Try again and enter a unique value." 11 50
         else
           FLine=$(</tmp/FullLine)
           got_them=1 # We have the hostname and direct URL
@@ -122,6 +126,7 @@ then
 
 fi # fi 6
 fi # fi 7
+fi # fi 8
 
 done
 clear
@@ -204,3 +209,4 @@ Internal error.  Must run FreeDNS again.
 EOF
 
 dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\nInternal error.  Press enter to exit.  Then, run FreeDNS Setup again" 9 50
+ 


### PR DESCRIPTION
If you create a new FreeDNS account and choose a user ID that has capital letters in it, FreeDNS will not inform you and approves your account.  However, your user ID will be converted to all lowercase letters.

If you attempt to log into FreeDNS with the original user ID containing capital letters, your login will be rejected.

If you log into FreeDNS, you can see your approved user ID, which is identical to the one you entered with all letters converted to lowercase.

This PR informs the user if they enter a user ID containing capital letters with the following dialog:
![Screenshot 2022-11-29 191602](https://user-images.githubusercontent.com/51497406/204677967-842bf523-5667-4791-9bf8-d4cbde51a3a9.png)

Thanks to @justinthomas for reporting this here: https://github.com/jamorham/nightscout-vps/pull/32.