### PR TITLE
Correct database size

### DIFF
--- a/NS_Install2.sh
+++ b/NS_Install2.sh
@@ -53,6 +53,8 @@ export ENABLE="careportal food boluscalc bwp cob bgi pump openaps rawbg iob upba
 export AUTH_DEFAULT_ROLES="denied"
 export PUMP_FIELDS="reservoir battery clock"
 export DEVICESTATUS_ADVANCED="true"
+export THEME="colors"
+export DBSIZE_MAX="20000"
 
 EOF
 


### PR DESCRIPTION
This PR enables colors and sets the maximum database size to 20000.

Without setting the max database size, the default is 500, which was appropriate for Heroku.

I also thought the majority would prefer to see colors instead of black and white.

This was tested by deleting the nsconfig file from a working system and rerunning installation step 2.
After completion and a reboot, the colors are enabled and the database size is accordingly shown.

The reason I chose 20000 was to leave 10G for Linux and swap file.  If you think we should set a smaller value, please go ahead and reduce the size.

To test this, backup your nsconfig file.  Then, delete /etc/nsconfig.  Then, replace /xDrip/scripts/NS_Install2.sh with the one from this PR.  Then, run installation phase 2.  