### PR TITLE
Add copy variables from Heroku to the menu

### DIFF
--- a/menu.sh
+++ b/menu.sh
@@ -16,13 +16,13 @@ Press Enter to execute the highlighted option.\n\n" 24 50 14\
  "1" "Status"\
  "2" "Installation phase 1 - 15 minutes"\
  "3" "Installation phase 2 - 5 minutes"\
- "4" "Edit variables"\
- "5" "Edit variables in a browser"\
- "6" "Copy data from another Nightscout"\
- "7" "Update scripts"\
- "8" "Backup MongoDB"\
- "9" "Restore MongoDB backup"\
- "10" "FreeDNS Setup"\
+ "4" "Edit variables in a browser"\
+ "5" "Copy Variables from Heroku"\
+ "6" "Update scripts"\
+ "7" "Backup MongoDB"\
+ "8" "Restore MongoDB backup"\
+ "9" "FreeDNS Setup"\
+ "10" "Copy data from another Nightscout"\
  "11" "Customize Nightscout"\
  "12" "Reboot server (Nightscout)"\
  "13" "Exit to shell (terminal)"\
@@ -43,19 +43,14 @@ sudo /xDrip/scripts/NS_Install2.sh
 ;;
 
 4)
-/xDrip/scripts/variables.sh
-;;
-
-5)
 /xDrip/scripts/varserver.sh
 ;;
 
-6)
-clear
-sudo /xDrip/scripts/clone_nightscout.sh
+5)
+/xDrip/scripts/GetHerokuVars.sh
 ;;
 
-7)
+6)
 cd /srv
 cd "$(< repo)"  # Go to the local database
 sudo git reset --hard  # delete any local edits.
@@ -66,17 +61,22 @@ clear
 sudo /xDrip/scripts/update_scripts.sh
 ;;
 
-8)
+7)
 /xDrip/scripts/backupmongo.sh
 ;;
 
-9)
+8)
 /xDrip/scripts/restoremongo.sh
+;;
+
+9)
+clear
+sudo /xDrip/scripts/ConfigureFreedns.sh
 ;;
 
 10)
 clear
-sudo /xDrip/scripts/ConfigureFreedns.sh
+sudo /xDrip/scripts/clone_nightscout.sh
 ;;
 
 11)


### PR DESCRIPTION
Edit:  I have to add that this does not work for me because I have enabled multi-factor authentication on Heroku.
I doubt that I am the only one who has done that.  Therefore, there will be others this will not work for.
But, I can simply log into Heroku and see all my variables.
That is why I prefer not to have this added to the menu.


This PR changes the menu.
It removed edit variables because we now have edit variables using a browser.
It adds copy variables from Heroku.  This is an existing utility.
It changes the order of some of the items on the menu.  
This is the new menu after this PR:
![Screenshot 2022-12-04 190024](https://user-images.githubusercontent.com/51497406/205523986-ef888d7e-3aa2-48ca-b59f-07ae103d4bdf.png)

How to test (how it was tested):
In your updated test virtual machine, edit the following file:  /xDrip/scripts/menu.sh
Replace the content with the file from this PR, the only modified item: https://github.com/Navid200/cgm-remote-monitor/blob/CopyVarsMenu/menu.sh
Close the terminal.  Open a new window.
Leave testing "Update scripts" to last.  Using that item will update the menu back to the way it was.