### PR TITLE
Status page update

### DIFF
--- a/Status.sh
+++ b/Status.sh
@@ -124,7 +124,7 @@ NS proc: $ns \n\
 FreeDNS: $FD
  " 24 50 2\
  "1" "Return"\
- "2" "Hostname"\
+ "2" "Hostname & API_SECRET"\
  3>&1 1>&2 2>&3)
  
  case $Choice in

--- a/Status.sh
+++ b/Status.sh
@@ -117,7 +117,7 @@ exit
 echo "your host name" $HOSTNAME
 dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\
 Don't disclose.\n\
-       FreeDNS hostname:  $HOSTNAME" 8 50
+FreeDNS hostname:  $HOSTNAME" 8 50
 ;;
 
 esac

--- a/Status.sh
+++ b/Status.sh
@@ -109,7 +109,7 @@ apisec=${split[1]}
 clear
 Choice=$(dialog --colors --nocancel --nook --menu "\
        \Zr Developed by the xDrip team \Zn\n\n\
-          \Zb Status         2022.12.05 \Zn\n\n\
+                \Zb Status       2022.12.05 \Zn\n\n\
 Zone: $Zone \n\
 RAM: $Ramsize \n\
 Disk type: "$disk" \n\

--- a/Status.sh
+++ b/Status.sh
@@ -115,7 +115,8 @@ exit
 2)
 . /etc/free-dns.sh
 echo "your host name" $hostname
-
+dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\
+$hostname" 10 50
 ;;
 
 esac

--- a/Status.sh
+++ b/Status.sh
@@ -90,6 +90,12 @@ if [ "$HOSTNAME" = "" ]
 then
 FD="No hostname"
 fi
+registered=$(nslookup $HOSTNAME|tail -n2|grep A|sed s/[^0-9.]//g)
+current=$(wget -q -O - http://checkip.dyndns.org|sed s/[^0-9.]//g)
+if [ ! "$registered" = "$current" ]
+then
+FD="Mismatch"
+fi
 
 clear
 Choice=$(dialog --colors --nocancel --nook --menu "\

--- a/Status.sh
+++ b/Status.sh
@@ -135,9 +135,9 @@ exit
 
 2)
 dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\
-Do not disclose.\n\
+        Do not disclose.\n\n\
 FreeDNS hostname:  $HOSTNAME\n\
-API-SECRET: $apisec" 9 50
+API-SECRET: $apisec" 10 50
 ;;
 
 esac

--- a/Status.sh
+++ b/Status.sh
@@ -116,8 +116,7 @@ exit
 . /etc/free-dns.sh
 echo "your host name" $HOSTNAME
 dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\
-Don't disclose.
-
+Don't disclose.\n\
 Hostname:  $HOSTNAME" 8 50
 ;;
 

--- a/Status.sh
+++ b/Status.sh
@@ -117,7 +117,7 @@ exit
 echo "your host name" $HOSTNAME
 dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\
 Don't disclose.\n\
-Hostname:  $HOSTNAME" 8 50
+       Hostname:  $HOSTNAME" 8 50
 ;;
 
 esac

--- a/Status.sh
+++ b/Status.sh
@@ -85,9 +85,10 @@ then
 branch="\Zb\Z1$(< /srv/brnch)\Zn"
 fi
 
-
-dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
-                \Zb Status \Zn\n\n\
+clear
+Choice=$(dialog --colors --nocancel --nook --menu "\
+       \Zr Developed by the xDrip team \Zn\n\n\
+          \Zb Status   2022.12.05 \Zn\n\n\
 Zone: "$Zone" \n\
 RAM: $Ramsize \n\
 Disk type: "$disk" \n\
@@ -99,5 +100,21 @@ HTTP & HTTPS:  $http \n\
 Swap: $swap \n\
 Mongo: $mongo \n\
 NS proc: $ns \n\
- " 22 50
+FreeDNS: 
+ " 24 50 2\
+ "1" "Return"\
+ "2" "Hostname"\
+ 3>&1 1>&2 2>&3)
+ 
+ case $Choice in
+ 
+ 1)
+exit
+;;
+
+2)
+exit
+;;
+
+esac
  

--- a/Status.sh
+++ b/Status.sh
@@ -85,11 +85,17 @@ then
 branch="\Zb\Z1$(< /srv/brnch)\Zn"
 fi
 
+. /etc/free-dns.sh
+if [ "$HOSTNAME" = "" ]
+then
+FD="No hostname"
+fi
+
 clear
 Choice=$(dialog --colors --nocancel --nook --menu "\
        \Zr Developed by the xDrip team \Zn\n\n\
           \Zb Status         2022.12.05 \Zn\n\n\
-Zone: "$Zone" \n\
+Zone: $Zone \n\
 RAM: $Ramsize \n\
 Disk type: "$disk" \n\
 Disk size: $disksz        $DiskUsedPercent used \n\
@@ -100,7 +106,7 @@ HTTP & HTTPS:  $http \n\
 Swap: $swap \n\
 Mongo: $mongo \n\
 NS proc: $ns \n\
-FreeDNS: 
+FreeDNS: $FD
  " 24 50 2\
  "1" "Return"\
  "2" "Hostname"\
@@ -113,8 +119,6 @@ exit
 ;;
 
 2)
-. /etc/free-dns.sh
-echo "your host name" $HOSTNAME
 dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\
 Do not disclose.\n\
 FreeDNS hostname:  $HOSTNAME" 8 50

--- a/Status.sh
+++ b/Status.sh
@@ -88,7 +88,7 @@ fi
 clear
 Choice=$(dialog --colors --nocancel --nook --menu "\
        \Zr Developed by the xDrip team \Zn\n\n\
-          \Zb Status   2022.12.05 \Zn\n\n\
+          \Zb Status         2022.12.05 \Zn\n\n\
 Zone: "$Zone" \n\
 RAM: $Ramsize \n\
 Disk type: "$disk" \n\

--- a/Status.sh
+++ b/Status.sh
@@ -117,7 +117,7 @@ exit
 echo "your host name" $HOSTNAME
 dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\
 Don't disclose.\n\
-       Hostname:  $HOSTNAME" 8 50
+       FreeDNS hostname:  $HOSTNAME" 8 50
 ;;
 
 esac

--- a/Status.sh
+++ b/Status.sh
@@ -116,7 +116,7 @@ exit
 . /etc/free-dns.sh
 echo "your host name" $HOSTNAME
 dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\
-Don't disclose.\n\
+Do not disclose.\n\
 FreeDNS hostname:  $HOSTNAME" 8 50
 ;;
 

--- a/Status.sh
+++ b/Status.sh
@@ -100,6 +100,12 @@ FD="Match"
 fi
 fi
 
+grep API_SECRET /etc/nsconfig | awk '{print $2}' > /tmp/apisecret
+FLine=$(</tmp/apisecret)
+IFS='"'
+read -a split <<< $FLine
+apisec=${split[1]}
+
 clear
 Choice=$(dialog --colors --nocancel --nook --menu "\
        \Zr Developed by the xDrip team \Zn\n\n\
@@ -130,7 +136,8 @@ exit
 2)
 dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\
 Do not disclose.\n\
-FreeDNS hostname:  $HOSTNAME" 8 50
+FreeDNS hostname:  $HOSTNAME\n\
+API-SECRET: $apisec" 9 50
 ;;
 
 esac

--- a/Status.sh
+++ b/Status.sh
@@ -116,7 +116,9 @@ exit
 . /etc/free-dns.sh
 echo "your host name" $HOSTNAME
 dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\
-$HOSTNAME" 10 50
+Don't disclose.
+
+$HOSTNAME" 8 50
 ;;
 
 esac

--- a/Status.sh
+++ b/Status.sh
@@ -113,7 +113,9 @@ exit
 ;;
 
 2)
-exit
+. /etc/free-dns.sh
+echo "your host name" $hostname
+
 ;;
 
 esac

--- a/Status.sh
+++ b/Status.sh
@@ -114,9 +114,9 @@ exit
 
 2)
 . /etc/free-dns.sh
-echo "your host name" $hostname
+echo "your host name" $HOSTNAME
 dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\
-$hostname" 10 50
+$HOSTNAME" 10 50
 ;;
 
 esac

--- a/Status.sh
+++ b/Status.sh
@@ -124,7 +124,7 @@ NS proc: $ns \n\
 FreeDNS: $FD
  " 24 50 2\
  "1" "Return"\
- "2" "Hostname & API_SECRET"\
+ "2" "Hostname and password"\
  3>&1 1>&2 2>&3)
  
  case $Choice in

--- a/Status.sh
+++ b/Status.sh
@@ -118,7 +118,7 @@ echo "your host name" $HOSTNAME
 dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\
 Don't disclose.
 
-$HOSTNAME" 8 50
+Hostname:  $HOSTNAME" 8 50
 ;;
 
 esac

--- a/Status.sh
+++ b/Status.sh
@@ -89,12 +89,15 @@ fi
 if [ "$HOSTNAME" = "" ]
 then
 FD="No hostname"
-fi
+else
 registered=$(nslookup $HOSTNAME|tail -n2|grep A|sed s/[^0-9.]//g)
 current=$(wget -q -O - http://checkip.dyndns.org|sed s/[^0-9.]//g)
 if [ ! "$registered" = "$current" ]
 then
 FD="Mismatch"
+else
+FD="Match"
+fi
 fi
 
 clear


### PR DESCRIPTION
1- Adds a date to the status page so that we can identify different versions in use.

2- Adds FreeDNS entry on the status page.  
It will be empty if the FreeDNS setup has not been executed yet.
It will show match if the two ips matched.
It will show mismatch if the two ips did not match.

3- Adds an option on the status page titled Hostname and password.
Choosing that option opens a new page showing the FreeDNS hostname and the API_SECRET with the note at the top warning the user not to disclose.

We need this mainly for item 2 to help Patrick and me provide support in public forums to users.

This is what the new status page looks like:
![Screenshot 2022-12-05 235050](https://user-images.githubusercontent.com/51497406/205818740-a5a43760-634c-4bef-af2e-28cbd087c5d6.png)

This is what the optional page looks like:
![Screenshot 2022-12-05 235136](https://user-images.githubusercontent.com/51497406/205818922-1c660390-ee8b-4819-9059-1f81905b967d.png)

