### PR TITLE
Status page update

### DIFF
--- a/Status.sh
+++ b/Status.sh
@@ -85,6 +85,7 @@ then
 branch="\Zb\Z1$(< /srv/brnch)\Zn"
 fi
 
+HOSTNAME=""
 . /etc/free-dns.sh
 if [ "$HOSTNAME" = "" ]
 then

--- a/Status.sh
+++ b/Status.sh
@@ -137,7 +137,7 @@ exit
 dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\
        \Zb\Z1 Do not disclose.\Zn\n\n\
 FreeDNS hostname:  $HOSTNAME\n\
-API-SECRET: $apisec" 10 50
+API_SECRET: $apisec" 10 50
 ;;
 
 esac

--- a/Status.sh
+++ b/Status.sh
@@ -135,7 +135,7 @@ exit
 
 2)
 dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\
-        Do not disclose.\n\n\
+       \Zb\Z1 Do not disclose.\Zn\n\n\
 FreeDNS hostname:  $HOSTNAME\n\
 API-SECRET: $apisec" 10 50
 ;;

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -102,7 +102,7 @@ fi
 
 clear
 dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\
-If any item is shown in red on the status page (shown next), it represents an incorrect parameter that could result in malfunction or cost.  \
+If any item above the line on the status page (shown next) is red, it represents an incorrect parameter that could result in malfunction or cost.  \
 Please take a note, delete the virtual machine, and create a new one.   For more detail, please refer to the guide." 12 50
 
 # Bring up the status page


### PR DESCRIPTION
1- Adds a date to the status page so that we can identify different versions in use.

2- Adds FreeDNS entry on the status page.  
It will show "No hostname" if the FreeDNS setup has not been executed yet.
It will show Match if the two ips matched.
It will show Mismatch if the two ips did not match.

3- Adds Certificate status.

4- Adds an option on the status page titled Hostname and password.
Choosing that option opens a new page showing the FreeDNS hostname and the API_SECRET with the note at the top warning the user not to disclose.

We need this mainly for items 2 and 3 to help Patrick and me provide support in public forums to users.

This is what the new status page looks like:
![Screenshot 2022-12-06 115154](https://user-images.githubusercontent.com/51497406/205973308-bece5ae9-6f80-4e5d-adb4-864828e2d3e3.png)


This is what the optional page looks like:
![Screenshot 2022-12-06 115336](https://user-images.githubusercontent.com/51497406/205973861-8d4f1ad9-ef4d-4a86-8e38-904fbd53b758.png)

This has been tested.
To test this, on an updated working test machine, replace /xDrip/scripts/Status.sh with the one from this PR.