### PR TITLE
Customize Nightscout update

### DIFF
--- a/update_nightscout.sh
+++ b/update_nightscout.sh
@@ -129,7 +129,9 @@ sleep 10
 done
 EOF
 
+clear
 dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
 The installation is complete.  A reboot is required to start Nightscout.  Press enter to reboot." 9 50 
+clear
 sudo reboot # Reboot so that Nightscout starts.
  

--- a/update_nightscout.sh
+++ b/update_nightscout.sh
@@ -129,5 +129,7 @@ sleep 10
 done
 EOF
 
+dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
+The installation is complete.  A reboot is required to start Nightscout.  Press enter to reboot." 8 50 
 sudo reboot # Reboot so that Nightscout starts.
  

--- a/update_nightscout.sh
+++ b/update_nightscout.sh
@@ -130,6 +130,6 @@ done
 EOF
 
 dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
-The installation is complete.  A reboot is required to start Nightscout.  Press enter to reboot." 8 50 
+The installation is complete.  A reboot is required to start Nightscout.  Press enter to reboot." 9 50 
 sudo reboot # Reboot so that Nightscout starts.
  


### PR DESCRIPTION
This PR changes the behavior of the customization routine.

When it is complete, it brings up a message informing the user that installation is complete and the user will need to press enter to reboot.
![Screenshot 2022-12-06 201256](https://user-images.githubusercontent.com/51497406/206063613-0f4a34f2-9bb0-417b-9ff7-7ccd2cac218f.png)

Right now, if the user leaves the computer and comes back and sees a disconnect message, they have no idea if installation completed or not because at the end, the script automatically reboots.  The screen looks exactly the same if there has been an automatic reboot or if there has been a random disconnect. 

After this PR, the user will know.  If they see the message, they know installation completed.  if they see a disconnect, they know there has been a random disconnect.

Tested
To test this, in a working updated test machine, replace /xDrip/scripts/update_nightscout.sh with the one from this PR. 