### PR TITLE
Minimal detect

### DIFF
--- a/Status.sh
+++ b/Status.sh
@@ -130,7 +130,7 @@ Disk size: $disksz        $DiskUsedPercent used \n\
 Ubuntu: $ubuntu \n\
 HTTP & HTTPS:  $http \n\
 ------------------------------------------ \n\
-Nightscout on Google Cloud: 2023.01.15\n\
+Nightscout on Google Cloud: 2023.01.17\n\
 $Missing \n\n\
 /$uname/$repo/$branch\n\
 Swap: $swap \n\

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin"
-# curl https://raw.githubusercontent.com/Navid200/cgm-remote-monitor/MoreMenu_Test/bootstrap.sh | bash
+# curl https://raw.githubusercontent.com/Navid200/cgm-remote-monitor/MinimalDetect/bootstrap.sh | bash
 
 echo 
 echo "Bootstrapping the installation files - Navid200"
@@ -23,7 +23,7 @@ clear
 sudo apt-get update
 sudo apt-get install dialog
 ubversion="$(cat /etc/issue | awk '{print $2}')"
-if [[ ! "$ubversion" = "20.04"* ]]
+if [[ ! "$ubversion" = "20.04"* ]] || [[ ! "$(which vi)" = "" ]] # If the selected version of ubuntu is not exactly what we want
 then
 clear
 dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\


### PR DESCRIPTION
If the user forgets to choose the minimal version of ubuntu instead of the regular version, the current release does not detect/flag it.

After this PR, the regular version will be flagged as unacceptable and the user will be asked to delete the virtual machine and recreate the virtual machine choosing the correct ubuntu version.

Edit:
I have tested this by executing this line (minus the hashtag): https://github.com/Navid200/cgm-remote-monitor/blob/1e9db2bbd4465bba9f014bda223108f7bb6d04f1/bootstrap.sh#L3