### PR TITLE
Remove FreeDNS from the menu

### DIFF
--- a/Status.sh
+++ b/Status.sh
@@ -80,7 +80,7 @@ repo="\Zb\Z1$(< /srv/repo)\Zn" # Set the color to red if the repository name is 
 fi
 
 branch="$(< /srv/brnch)"
-if [ ! "$(< /srv/brnch)" = "vps-1" ] || [ ! "$(< /srv/brnch)" = "vps-dev" ]
+if [ ! "$(< /srv/brnch)" = "vps-1" ] && [ ! "$(< /srv/brnch)" = "vps-dev" ]
 then
 branch="\Zb\Z1$(< /srv/brnch)\Zn" # Set the color to red if the branch name is not either vps-1 or vps-dev.
 fi
@@ -130,7 +130,7 @@ Disk size: $disksz        $DiskUsedPercent used \n\
 Ubuntu: $ubuntu \n\
 HTTP & HTTPS:  $http \n\
 ------------------------------------------ \n\
-Nightscout on Google Cloud: 2023.01.28\n\
+Nightscout on Google Cloud: 2023.02.09\n\
 $Missing \n\n\
 /$uname/$repo/$branch\n\
 Swap: $swap \n\

--- a/Status.sh
+++ b/Status.sh
@@ -116,8 +116,17 @@ fi
 Missing=""
 if [ "$(which qrencode)" = "" ]
 then
-  Missing="\Zb\Z1Missing packages\Zn"
+  Missing="\Zb\Z1Missing packages  \Zn"
 fi
+
+# Verify that Installation phase 1 has been executed after bootstrap
+Phase1=""
+cd /srv
+cd "$(< repo)"
+if [ ! -s ./node_modules ]
+then
+  Phase1="\Zb\Z1Missing node_modules\Zn"
+fi  
 
 clear
 Choice=$(dialog --colors --nocancel --nook --menu "\
@@ -131,7 +140,7 @@ Ubuntu: $ubuntu \n\
 HTTP & HTTPS:  $http \n\
 ------------------------------------------ \n\
 Nightscout on Google Cloud: 2023.02.09\n\
-$Missing \n\n\
+$Missing $Phase1 \n\n\
 /$uname/$repo/$branch\n\
 Swap: $swap \n\
 Mongo: $mongo \n\

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin"
-# curl https://raw.githubusercontent.com/Navid200/cgm-remote-monitor/DevBranchSetup_Test/bootstrap.sh | bash
+# curl https://raw.githubusercontent.com/Navid200/cgm-remote-monitor/RemoveFreeDNS_Test/bootstrap.sh | bash
 
 echo 
 echo "Bootstrapping the installation files - Navid200"
@@ -26,9 +26,9 @@ fi
 clear
 
 ubversion="$(cat /etc/issue | awk '{print $2}')"
-if [ "$ExistingSystem" = "0" ]  # If this is not an existing installation
+if [ "$ExistingSystem" = "0" ]  # Only if this is not an existing installation
 then
-  if [[ ! "$ubversion" = "20.04"* ]] || [[ ! "$(which vi)" = "" ]] # If the selected version of ubuntu is not exactly what we want
+  if [[ ! "$ubversion" = "20.04"* ]] || [[ ! "$(which vi)" = "" ]] # If the selected version of ubuntu is not what we want or if the main version has been installed instead of minimal
   then
   clear
   dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
@@ -45,12 +45,12 @@ then
 sudo mkdir /xDrip
 fi
 cd /xDrip
-sudo rm -rf scripts
-sudo -rf ConfigServer
+sudo rm -rf scripts # Delete all the scripts
+sudo -rf ConfigServer # Delete the config server
 sudo mkdir scripts
 
 cd /srv
-sudo rm -rf *
+sudo rm -rf * # Delete everything in the /srv directory
 sudo git clone https://github.com/jamorham/nightscout-vps.git  # ✅✅✅✅✅ Main - Uncomment before PR.
 #sudo git clone https://github.com/Navid200/cgm-remote-monitor.git  # ⛔⛔⛔⛔⛔ For test - Comment out before PR.
 
@@ -58,7 +58,7 @@ ls > /tmp/repo
 sudo mv -f /tmp/repo .    # The repository name is now in /srv/repo
 cd "$(< repo)"
 sudo git checkout vps-dev  # ✅✅✅✅✅ Main - Uncomment before PR.
-#sudo git checkout DevBranchSetup_Test  # ⛔⛔⛔⛔⛔ For test - Comment out before PR.
+#sudo git checkout RemoveFreeDNS_Test  # ⛔⛔⛔⛔⛔ For test - Comment out before PR.
 
 sudo git branch > /tmp/branch
 grep "*" /tmp/branch | awk '{print $2}' > /tmp/brnch
@@ -80,12 +80,6 @@ fi
 
 sudo chmod 755 *.sh
 sudo cp -f update_scripts.sh /xDrip/scripts
-
-# Updating the scripts
-cat > /tmp/nodialog_update_scripts << EOF
-Don't show dialog
-
-EOF
 
 /xDrip/scripts/update_scripts.sh
 

--- a/menu_GC_Setup.sh
+++ b/menu_GC_Setup.sh
@@ -11,11 +11,10 @@ Use the arrow keys to move the cursor.\n\
 Press Enter to execute the highlighted option.\n" 17 50 7\
  "1" "Install Nightscout phase 1 - 15 minutes"\
  "2" "Install Nightscout phase 2 - 5 minutes"\
- "3" "FreeDNS Setup"\
- "4" "Update platform"\
- "5" "Bootstrap the stable release"\
- "6" "Bootstrap the dev. release (advanced)"\
- "7" "Return"\
+ "3" "Update platform"\
+ "4" "Bootstrap the stable release"\
+ "5" "Bootstrap the dev. release (advanced)"\
+ "6" "Return"\
  3>&1 1>&2 2>&3)
 
 case $Choice in
@@ -29,11 +28,6 @@ sudo /xDrip/scripts/NS_Install2.sh
 ;;
 
 3)
-clear
-sudo /xDrip/scripts/ConfigureFreedns.sh
-;;
-
-4)
 cd /srv
 cd "$(< repo)"  # Go to the local database
 sudo git reset --hard  # delete any local edits.
@@ -48,15 +42,15 @@ dialog --colors --msgbox "        \Zr Developed by the xDrip team \Zn\n\n\
 Close this terminal to complete updates." 7 50
 ;;
 
-5)
+4)
 curl https://raw.githubusercontent.com/jamorham/nightscout-vps/vps-1/bootstrap.sh | bash
 ;;
 
-6)
+5)
 curl https://raw.githubusercontent.com/jamorham/nightscout-vps/vps-dev/bootstrap.sh | bash
 ;;
 
-7)
+6)
 ;;
 
 esac


### PR DESCRIPTION
This PR removes the FreeDNS utility from the menu.

The FreeDNS utility was originally created to allow users switch from noip.com to FreeDNS.
We have since made Nightscout install phase 2 call the same utility (FreeDNS).
If someone is still using noip.com, they can run installation phase 2 in order to run the FreeDNS utility.

There is no reason to have FreeDNS on the menu.  the danger leaving it there is that users may use it when running installation phase 2 is preferred.

There is no disadvantage in running installation phase 2 instead.    If you don't want to change the API-SECRET, you just press enter.  

If the node_modules directory is missing, a note will appear on the status page.
Therefore, if someone runs bootstrap and does not run Nightscout installation phase 1 after, this note will let the supporters know.
![Screenshot 2023-02-09 003156](https://user-images.githubusercontent.com/51497406/217727425-f7724775-85b0-4a45-adcf-8775fa2954d4.png)

This PR has been tested in this repository:  https://github.com/Navid200/cgm-remote-monitor/blob/RemoveFreeDNS_Test
If you want to test, please run this bootstrap: 
```
curl https://raw.githubusercontent.com/Navid200/cgm-remote-monitor/RemoveFreeDNS_Test/bootstrap.sh | bash
```
