### PR TITLE
FreeDNS update

### DIFF
--- a/ConfigureFreedns.sh
+++ b/ConfigureFreedns.sh
@@ -212,5 +212,5 @@ cat > /tmp/FreeDNS_Failed << EOF
 Internal error.  Must run FreeDNS again.
 EOF
 
-dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\nInternal error.  Press enter to exit.  Then, run FreeDNS Setup again" 9 50
+dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\nInternal error.  Press enter to exit.  Then, run "Install Nightscout phase 2" again" 9 50
  

--- a/ConfigureFreedns.sh
+++ b/ConfigureFreedns.sh
@@ -212,5 +212,5 @@ cat > /tmp/FreeDNS_Failed << EOF
 Internal error.  Must run FreeDNS again.
 EOF
 
-dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nInternal error.  Press enter to exit.  Then, run \"Install Nightscout phase 2\" again." 9 50
+dialog --colors --msgbox "        \Zr Developed by the xDrip team \Zn\n\nInternal error.  Press enter to exit.  Then, run \"Install Nightscout phase 2\" again." 8 50
  

--- a/ConfigureFreedns.sh
+++ b/ConfigureFreedns.sh
@@ -212,5 +212,5 @@ cat > /tmp/FreeDNS_Failed << EOF
 Internal error.  Must run FreeDNS again.
 EOF
 
-dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\nInternal error.  Press enter to exit.  Then, run "Install Nightscout phase 2" again" 9 50
+dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\nInternal error.  Press enter to exit.  Then, run \"Install Nightscout phase 2\" again." 9 50
  

--- a/ConfigureFreedns.sh
+++ b/ConfigureFreedns.sh
@@ -212,5 +212,5 @@ cat > /tmp/FreeDNS_Failed << EOF
 Internal error.  Must run FreeDNS again.
 EOF
 
-dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\nInternal error.  Press enter to exit.  Then, run \"Install Nightscout phase 2\" again." 9 50
+dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nInternal error.  Press enter to exit.  Then, run \"Install Nightscout phase 2\" again." 9 50
  

--- a/Status.sh
+++ b/Status.sh
@@ -139,7 +139,7 @@ Disk size: $disksz        $DiskUsedPercent used \n\
 Ubuntu: $ubuntu \n\
 HTTP & HTTPS:  $http \n\
 ------------------------------------------ \n\
-Nightscout on Google Cloud: 2023.02.15\n\
+Nightscout on Google Cloud: 2023.02.19\n\
 $Missing $Phase1 \n\n\
 /$uname/$repo/$branch\n\
 Swap: $swap \n\


### PR DESCRIPTION
We now use install Nightscout phase 2 instead of Config FreeDNS.
The FreeDNS utility is called by Install Nightscout phase 2.

We currently have a dialog that asks the user to run the FreeDNS utility.
This PR changes that dialog to ask the user to run Install Nightscout phase 2 instead.