### PR TITLE
Backup restore update test

### DIFF
--- a/ConfigureFreedns.sh
+++ b/ConfigureFreedns.sh
@@ -201,10 +201,6 @@ do
          sleep 60
     else
         # worked, geting out of the loop.
-        # Add log
-        rm -rf /tmp/Logs
-        echo -e "FreeDNS setup completed     $(date)\n" | cat - /xDrip/Logs > /tmp/Logs
-        sudo /bin/cp -f /tmp/Logs /xDrip/Logs
         exit 1
     fi
 done

--- a/Status.sh
+++ b/Status.sh
@@ -113,8 +113,9 @@ cert="Valid"
 fi
 
 # Verify that the latest added package has been installed
+# The utility must be the last added utility to the update_packages.sh file.
 Missing=""
-if [ "$(which qrencode)" = "" ]
+if [ "$(which file)" = "" ]
 then
   Missing="\Zb\Z1Missing packages  \Zn"
 fi
@@ -139,7 +140,7 @@ Disk size: $disksz        $DiskUsedPercent used \n\
 Ubuntu: $ubuntu \n\
 HTTP & HTTPS:  $http \n\
 ------------------------------------------ \n\
-Nightscout on Google Cloud: 2023.02.19\n\
+Nightscout on Google Cloud: 2023.02.23\n\
 $Missing $Phase1 \n\n\
 /$uname/$repo/$branch\n\
 Swap: $swap \n\

--- a/Status.sh
+++ b/Status.sh
@@ -140,7 +140,7 @@ Disk size: $disksz        $DiskUsedPercent used \n\
 Ubuntu: $ubuntu \n\
 HTTP & HTTPS:  $http \n\
 ------------------------------------------ \n\
-Nightscout on Google Cloud: 2023.02.24\n\
+Nightscout on Google Cloud: 2023.02.28\n\
 $Missing $Phase1 \n\n\
 /$uname/$repo/$branch\n\
 Swap: $swap \n\

--- a/Status.sh
+++ b/Status.sh
@@ -140,7 +140,7 @@ Disk size: $disksz        $DiskUsedPercent used \n\
 Ubuntu: $ubuntu \n\
 HTTP & HTTPS:  $http \n\
 ------------------------------------------ \n\
-Nightscout on Google Cloud: 2023.02.23\n\
+Nightscout on Google Cloud: 2023.02.24\n\
 $Missing $Phase1 \n\n\
 /$uname/$repo/$branch\n\
 Swap: $swap \n\

--- a/backupmongo.sh
+++ b/backupmongo.sh
@@ -22,8 +22,10 @@ dialog --exit-label "Try again" --msgbox "A file with the same name exists.\n\
 Choose a different filename." 7 37
 clear
 else
-mongodump --gzip --archive=$Filename
+mongodump --gzip --archive=/tmp/database.gz
 exec 3>&-
+tar -cf $Filename /tmp/database.gz /etc/nsconfig
+
 dialog --msgbox "Backup is complete.\n\
 However, it is on the same virtual machine as\n\
 your MongoDB.\n\

--- a/backupmongo.sh
+++ b/backupmongo.sh
@@ -18,8 +18,9 @@ fi
 
 if [ -s $Filename ]
 then
-dialog --exit-label "Try again" --msgbox "A file with the same name exists.\n\
-Choose a different filename." 7 37
+dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\n\
+A file with the same name exists.\n\
+Choose a different filename." 8 50
 clear
 else
 mongodump --gzip --archive=/tmp/database.gz
@@ -28,12 +29,10 @@ cd /tmp
 cp /etc/nsconfig .
 tar -cf ~/$Filename database.gz nsconfig
 
-dialog --msgbox "Backup is complete.\n\
-However, it is on the same virtual machine as\n\
-your MongoDB.\n\
-It's best to download the file to your computer\n\
-for safekeeping.\n\
-See the guide for how to download." 10 51
+dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\n\
+Backup is complete.\n\
+However, it is on the same virtual machine that your database and variables are on.  It's best to download the file to your computer for safekeeping.\n\
+See the guide for how to download." 11 50
 clear
 exit
 fi

--- a/backupmongo.sh
+++ b/backupmongo.sh
@@ -32,7 +32,7 @@ tar -cf ~/$Filename database.gz nsconfig
 dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\n\
 Backup is complete.\n\
 However, it is on the same virtual machine that your database and variables are on.  It's best to download the file to your computer for safekeeping.\n\
-See the guide for how to download." 11 50
+See the guide for how to download." 12 50
 clear
 exit
 fi

--- a/backupmongo.sh
+++ b/backupmongo.sh
@@ -26,7 +26,7 @@ mongodump --gzip --archive=/tmp/database.gz
 exec 3>&-
 cd /tmp
 cp /etc/nsconfig .
-tar -cf $Filename database.gz nsconfig
+tar -cf ~/$Filename database.gz nsconfig
 
 dialog --msgbox "Backup is complete.\n\
 However, it is on the same virtual machine as\n\

--- a/backupmongo.sh
+++ b/backupmongo.sh
@@ -24,7 +24,9 @@ clear
 else
 mongodump --gzip --archive=/tmp/database.gz
 exec 3>&-
-tar -cf $Filename /tmp/database.gz /etc/nsconfig
+cd /tmp
+cp /etc/nsconfig .
+tar -cf $Filename database.gz nsconfig
 
 dialog --msgbox "Backup is complete.\n\
 However, it is on the same virtual machine as\n\

--- a/backupmongo.sh
+++ b/backupmongo.sh
@@ -32,7 +32,7 @@ tar -cf ~/$Filename database.gz nsconfig
 dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\n\
 Backup is complete.\n\
 However, it is on the same virtual machine that your database and variables are on.  It's best to download the file to your computer for safekeeping.\n\
-See the guide for how to download." 12 50
+See the guide for how to download." 13 50
 clear
 exit
 fi

--- a/backupmongo.sh
+++ b/backupmongo.sh
@@ -20,7 +20,7 @@ if [ -s $Filename ]
 then
 dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\n\
 A file with the same name exists.\n\
-Choose a different filename." 8 50
+Choose a different filename." 9 50
 clear
 else
 mongodump --gzip --archive=/tmp/database.gz

--- a/menu_Data.sh
+++ b/menu_Data.sh
@@ -10,8 +10,8 @@ Choice=$(dialog --colors --nocancel --nook --menu "\
 Use the arrow keys to move the cursor.\n\
 Press Enter to execute the highlighted option.\n" 14 50 4\
  "1" "Copy data from another Nightscout"\
- "2" "Backup MongoDB"\
- "3" "Restore MongoDB"\
+ "2" "Backup"\
+ "3" "Restore"\
  "4" "Return"\
  3>&1 1>&2 2>&3)
 

--- a/menu_Data.sh
+++ b/menu_Data.sh
@@ -10,8 +10,8 @@ Choice=$(dialog --colors --nocancel --nook --menu "\
 Use the arrow keys to move the cursor.\n\
 Press Enter to execute the highlighted option.\n" 14 50 4\
  "1" "Copy data from another Nightscout"\
- "2" "Backup"\
- "3" "Restore"\
+ "2" "Backup MongoDB and variables"\
+ "3" "Restore MongoDB and/or variables"\
  "4" "Return"\
  3>&1 1>&2 2>&3)
 

--- a/restoremongo.sh
+++ b/restoremongo.sh
@@ -3,7 +3,7 @@
 while :
 do
 goback=0 # Reset the loop
-File=$(dialog --title "Select the backup file to restore" --fselect ~/ 11 50 3>&1 1>&2 2>&3)
+File=$(dialog --title "Select the backup file to restore" --fselect ~/ 10 50 3>&1 1>&2 2>&3)
 key=$?
 
 if [ $key = 255 ] || [ $key = 1 ]
@@ -17,7 +17,7 @@ if [ "$(file -b "$File")" = "directory" ]
 then
   dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
 You need to move the cursor over the filename in the right pane and press space so that it is shown in the field at the bottom. Then, press enter.\n\
-Please try again." 10 50
+Please try again." 11 50
 goback=1 # Don't execute the remaining part of the loop
 fi
 

--- a/restoremongo.sh
+++ b/restoremongo.sh
@@ -81,6 +81,7 @@ esac
       if [ $var -eq 1 ]
       then
         sudo cp -f nsconfig /etc/nsconfig
+        clear
         dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nThe variables have been restored from backup.  You need to restart the server for the updated variables to take effect." 9 50
       fi
       exit
@@ -93,7 +94,7 @@ then
   if [ "$(file -b "$File" | awk '{print $1}')" = "gzip" ]
   then
     dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
-The backup only contains the database.  Press enter to restore it." 11 50
+The backup only contains a database.  Press enter to import it." 11 50
     key=$?
     if [ $key = 255 ]
     then

--- a/restoremongo.sh
+++ b/restoremongo.sh
@@ -74,7 +74,7 @@ esac
         then
           dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nThe database import failed.  Please report." 8 50
         else
-          dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nDatabase restore is complete.  Press enter to proceed." 8 50
+          dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nDatabase has been imported." 8 50
         fi
       fi
       
@@ -104,10 +104,10 @@ The backup only contains the database.  Press enter to restore it." 11 50
     fail=$?
     if [ $fail -eq 1 ]
     then
-      dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nThe database import failed.  Please report." 11 50
+      dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nDatabase import failed.  Please report." 11 50
       exit
     else
-      dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nImported the backed up database." 8 50
+      dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nDatabase has been imported." 8 50
       exit
     fi
   fi

--- a/restoremongo.sh
+++ b/restoremongo.sh
@@ -3,12 +3,12 @@
 while :
 do
 goback=0 # Reset the loop
-File=$(dialog --title "Select the backup file to restore" --fselect ~/ 10 50 3>&1 1>&2 2>&3)
+File=$(dialog --title "Select the backup file for restore" --fselect ~/ 10 50 3>&1 1>&2 2>&3)
 key=$?
 
 if [ $key = 255 ] || [ $key = 1 ]
 then
-exit
+  exit
 fi
 
 echo "$File"
@@ -37,24 +37,51 @@ then
       rm -f /tmp/database.gz
       tar -xf $File -C /tmp/.
       cd /tmp
-      mongorestore --gzip --archive=database.gz
-      fail=$?
       clear
-      if [ $fail = 1 ]
+      Choice=$(dialog --colors --nocancel --nook --menu "\
+        \Zr Developed by the xDrip team \Zn\n\n\
+Use the arrow keys to move the cursor.\n\
+Press Enter to execute the highlighted option.\n" 14 50 3\
+      "1" "Restore MongoDB only"\
+      "2" "Restore variables only"\
+      "3" "Restore MongoDB and variables"\
+      3>&1 1>&2 2>&3)
+      
+      case $Choice in
+      
+      db=0
+      var=0;
+      1)
+      db=1
+      ;;
+      
+      2)
+      var=1
+      ;;
+      
+      3)
+      db=1
+      var=1
+      ;;
+      
+      esac
+      
+      if [ $db -eq 1 ]
       then
-        dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nThe database import failed.  Please report." 8 50
-        goback=1
-      else
-        dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nThe database import is complete.  Press enter to also restore Nightscout variables from the backup.  Or, press escape to leave your variables as they are." 10 50
-        key=$?
-        if [ $key = 255 ]
+        mongorestore --gzip --archive=database.gz
+        fail=$?
+        if [ $fail = 1 ]
         then
-          exit
+          dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nThe database import failed.  Please report." 8 50
         fi
+      fi
+      
+      if [ var -eq 1 ]
+      then
         sudo cp -f nsconfig /etc/nsconfig
         dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nThe variables have been restored from backup.  You need to restart the server for the updated variables to take effect." 10 50
-        exit
       fi
+      exit
     fi  
   fi
 fi
@@ -63,15 +90,20 @@ if [ $goback -eq 0 ]
 then
   if [ "$(file -b "$File" | awk '{print $1}')" = "gzip" ]
   then
+    dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
+The backup only contains the database.  Press enter to restore it." 11 50
+    key=$?
+    if [ $key = 255 ]
+    then
+      exit
+    fi
     mongorestore --gzip --archive=$File
     clear
     fail=$?
     if [ $fail -eq 1 ]
     then
-      dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
-You need to move the cursor over the filename in the right pane and press space so that it is shown in the field at the bottom. Then, press enter.\n\
-Please try again." 11 50
-      goback=1
+      dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nThe database import failed.  Please report." 11 50
+      exit
     else
       dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nImported the backed up database." 8 50
       exit

--- a/restoremongo.sh
+++ b/restoremongo.sh
@@ -71,7 +71,7 @@ exit
       
 esac
       
-      if [ $db -eq 1 ]
+      if [ $db -eq 1 ] # If the user chose to restore MongoDB
       then
         mongorestore --gzip --archive=database.gz
         fail=$?
@@ -85,7 +85,7 @@ esac
           then
             dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nDatabase has been imported.\nThe variables will not be restored.  But, you can view them at /tmp/nsconfig." 9 50
           else # If the user chose to also restore the variables
-            dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nDatabase has been imported." 9 50
+            dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nDatabase has been imported." 8 50
           fi
         fi
       fi

--- a/restoremongo.sh
+++ b/restoremongo.sh
@@ -45,7 +45,7 @@ then
         dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nThe database import failed.  Please report." 8 50
         goback=1
       else
-        dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nThe database import is complete.  Press enter to also restore Nightscout variables from the backup.  Or, press escape not to." 10 50
+        dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nThe database import is complete.  Press enter to also restore Nightscout variables from the backup.  Or, press escape to leave your variables as they are." 10 50
         key=$?
         if [ $key = 255 ]
         then
@@ -72,7 +72,7 @@ You need to move the cursor over the filename in the right pane and press space 
 Please try again." 11 50
       goback=1
     else
-      dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\Imported the backed up database." 11 50
+      dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nImported the backed up database." 8 50
       exit
     fi
   fi

--- a/restoremongo.sh
+++ b/restoremongo.sh
@@ -13,10 +13,25 @@ exit
 fi
 
 echo "$File"
-
-if [ "$(file -b e3rfd | awk '{print $2}')" = "tar" = "tar" ]
+if [ "$(file -b "$File" | awk '{print $2}')" = "tar" ]
 then
+  if [ ! "$(tar -tf $File 'database.gz')" = "database.gz" ] || [ ! "$(tar -tf $File 'nsconfig')" = "nsconfig" ]
+  then
+    dialog --msgbox "Error\n The backup file may be corrupt.  Please report." 10 50
+    exit
+  fi
+  rm -f /tmp/nsconfig
+  rm -f /tmp/database.gz
   tar -xf $File -C /tmp/.
+  cd /tmp
+  mongorestore --gzip --archive=database.gz
+  fail=$?
+  if [ $fail = 1 ]
+  then
+    dialog --msgbox "Error\n The backup file may be corrupted.  Please report." 10 50
+  else
+    
+  fi
 fi
 
 mongorestore --gzip --archive=$File

--- a/restoremongo.sh
+++ b/restoremongo.sh
@@ -15,11 +15,9 @@ echo "$File"
 
 if [ "$(file -b "$File")" = "directory" ]
 then
-  dialog --msgbox "Error\n\
-You need to move the cursor over the filename\n\
-in the right pane and press space so that it\n\
-is shown in the field at the bottom.\n\
-Then, move the cursor over OK and press enter." 10 50
+  dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
+You need to move the cursor over the filename in the right pane and press space so that it is shown in the field at the bottom. Then, move the cursor over OK and press enter.\n\
+Please try again." 10 50
 goback=1 # Don't execute the remaining part of the loop
 fi
 

--- a/restoremongo.sh
+++ b/restoremongo.sh
@@ -47,24 +47,24 @@ Press Enter to execute the highlighted option.\n" 14 50 3\
  "3" "Restore MongoDB and variables"\
  3>&1 1>&2 2>&3)
       
-      case $Choice in
-      
       db=0
       var=0;
-      1)
-      db=1
-      ;;
+case $Choice in
       
-      2)
-      var=1
-      ;;
+1)
+db=1
+;;
       
-      3)
-      db=1
-      var=1
-      ;;
+2)
+var=1
+;;
       
-      esac
+3)
+db=1
+var=1
+;;
+      
+esac
       
       if [ $db -eq 1 ]
       then

--- a/restoremongo.sh
+++ b/restoremongo.sh
@@ -42,10 +42,10 @@ then
         \Zr Developed by the xDrip team \Zn\n\n\
 Use the arrow keys to move the cursor.\n\
 Press Enter to execute the highlighted option.\n" 14 50 3\
-      "1" "Restore MongoDB only"\
-      "2" "Restore variables only"\
-      "3" "Restore MongoDB and variables"\
-      3>&1 1>&2 2>&3)
+ "1" "Restore MongoDB only"\
+ "2" "Restore variables only"\
+ "3" "Restore MongoDB and variables"\
+ 3>&1 1>&2 2>&3)
       
       case $Choice in
       

--- a/restoremongo.sh
+++ b/restoremongo.sh
@@ -16,7 +16,7 @@ echo "$File"
 if [ "$(file -b "$File")" = "directory" ]
 then
   dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
-You need to move the cursor over the filename in the right pane and press space so that it is shown in the field at the bottom. Then, move the cursor over OK and press enter.\n\
+You need to move the cursor over the filename in the right pane and press space so that it is shown in the field at the bottom. Then, press enter.\n\
 Please try again." 10 50
 goback=1 # Don't execute the remaining part of the loop
 fi

--- a/restoremongo.sh
+++ b/restoremongo.sh
@@ -4,18 +4,16 @@ while :
 do
 goback=0 # Reset the loop
 File=$(dialog --title "Select the backup file to restore" --fselect ~/ 10 50 3>&1 1>&2 2>&3)
-
 key=$?
 
 if [ $key = 255 ] || [ $key = 1 ]
 then
-clear
 exit
 fi
 
 echo "$File"
 
-if [ "$File" = "" ]
+if [ file -b "$File" = "directory" ]
 then
   dialog --msgbox "Error\n\
 You need to move the cursor over the filename\n\

--- a/restoremongo.sh
+++ b/restoremongo.sh
@@ -76,7 +76,7 @@ esac
         fi
       fi
       
-      if [ var -eq 1 ]
+      if [ $var -eq 1 ]
       then
         sudo cp -f nsconfig /etc/nsconfig
         dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nThe variables have been restored from backup.  You need to restart the server for the updated variables to take effect." 10 50

--- a/restoremongo.sh
+++ b/restoremongo.sh
@@ -52,6 +52,7 @@ then
           exit
         fi
         sudo cp -f nsconfig /etc/nsconfig
+        dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nThe variables have been restored from backup.  You need to restart the server for the updated variables to take effect." 10 50
         exit
       fi
     fi  

--- a/restoremongo.sh
+++ b/restoremongo.sh
@@ -41,12 +41,30 @@ then
       fail=$?
       if [ $fail = 1 ]
       then
-        dialog --msgbox "Error\n The database restore failed.  Please report." 10 50
+        dialog --msgbox "Error\n The database restore failed.  Please report." 8 50
         goback=1
       else
         echo "nsconfig restore"
+        goback=1
       fi
     fi  
+  fi
+fi
+
+if [ $goback -eq 0 ]
+then
+  if [ "$(file -b "$File" | awk '{print $1}')" = "gzip" ]
+  then
+    mongorestore --gzip --archive=$File
+    fail=$?
+    if [ $fail -eq 1 ]
+    then
+      clear
+      dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
+You need to move the cursor over the filename in the right pane and press space so that it is shown in the field at the bottom. Then, press enter.\n\
+Please try again." 11 50
+      goback=1
+    fi
   fi
 fi
 done

--- a/restoremongo.sh
+++ b/restoremongo.sh
@@ -28,7 +28,7 @@ then
   fail=$?
   if [ $fail = 1 ]
   then
-    dialog --msgbox "Error\n The backup file may be corrupted.  Please report." 10 50
+    dialog --msgbox "Error\n The database restore failed.  Please report." 10 50
   else
     
   fi

--- a/restoremongo.sh
+++ b/restoremongo.sh
@@ -15,6 +15,7 @@ echo "$File"
 
 if [ "$(file -b "$File")" = "directory" ]
 then
+  clear
   dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
 You need to move the cursor over the filename in the right pane and press space so that it is shown in the field at the bottom. Then, press enter.\n\
 Please try again." 11 50

--- a/restoremongo.sh
+++ b/restoremongo.sh
@@ -79,7 +79,7 @@ esac
       if [ $var -eq 1 ]
       then
         sudo cp -f nsconfig /etc/nsconfig
-        dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nThe variables have been restored from backup.  You need to restart the server for the updated variables to take effect." 10 50
+        dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nThe variables have been restored from backup.  You need to restart the server for the updated variables to take effect." 9 50
       fi
       exit
     fi  

--- a/restoremongo.sh
+++ b/restoremongo.sh
@@ -41,10 +41,11 @@ then
       Choice=$(dialog --colors --nocancel --nook --menu "\
         \Zr Developed by the xDrip team \Zn\n\n\
 Use the arrow keys to move the cursor.\n\
-Press Enter to execute the highlighted option.\n" 14 50 3\
+Press Enter to execute the highlighted option.\n" 14 50 4\
  "1" "Restore MongoDB only"\
  "2" "Restore variables only"\
  "3" "Restore MongoDB and variables"\
+ "4" "Exit"\
  3>&1 1>&2 2>&3)
       
       db=0
@@ -62,6 +63,10 @@ var=1
 3)
 db=1
 var=1
+;;
+
+4)
+exit
 ;;
       
 esac

--- a/restoremongo.sh
+++ b/restoremongo.sh
@@ -2,6 +2,7 @@
 
 while :
 do
+goback=0 # Reset the loop
 File=$(dialog --title "Select the backup file to restore" --fselect ~/ 10 50 3>&1 1>&2 2>&3)
 
 key=$?
@@ -13,44 +14,43 @@ exit
 fi
 
 echo "$File"
-if [ "$(file -b "$File" | awk '{print $2}')" = "tar" ]
-then
-  if [ ! "$(tar -tf $File 'database.gz')" = "database.gz" ] || [ ! "$(tar -tf $File 'nsconfig')" = "nsconfig" ]
-  then
-    dialog --msgbox "Error\n The backup file may be corrupt.  Please report." 10 50
-    exit
-  fi
-  rm -f /tmp/nsconfig
-  rm -f /tmp/database.gz
-  tar -xf $File -C /tmp/.
-  cd /tmp
-  mongorestore --gzip --archive=database.gz
-  fail=$?
-  if [ $fail = 1 ]
-  then
-    dialog --msgbox "Error\n The database restore failed.  Please report." 10 50
-  else
-    
-  fi
-fi
 
-mongorestore --gzip --archive=$File
-fail=$?
-if [ $fail = 1 ]
+if [ "$File" = "" ]
 then
-dialog --msgbox "Error\n\
+  dialog --msgbox "Error\n\
 You need to move the cursor over the filename\n\
 in the right pane and press space so that it\n\
 is shown in the field at the bottom.\n\
 Then, move the cursor over OK and press enter." 10 50
-else
-clear
-# Add log
-rm -rf /tmp/Logs
-echo -e "Mongo restore     $(date)\n" | cat - /xDrip/Logs > /tmp/Logs
-sudo /bin/cp -f /tmp/Logs /xDrip/Logs
-exit
+goback=1 # Don't execute the remaining part of the loop
 fi
 
+if [ $goback -eq 0 ]
+then
+  if [ "$(file -b "$File" | awk '{print $2}')" = "tar" ]
+  then
+    if [ ! "$(tar -tf $File 'database.gz')" = "database.gz" ] || [ ! "$(tar -tf $File 'nsconfig')" = "nsconfig" ]
+    then
+      dialog --msgbox "Error\n The backup file may be corrupt.  Please report." 10 50
+      goback=1 # Don't execute the rest of the loop
+    fi
+    if [ $goback -eq 0 ]
+    then
+      rm -f /tmp/nsconfig
+      rm -f /tmp/database.gz
+      tar -xf $File -C /tmp/.
+      cd /tmp
+      mongorestore --gzip --archive=database.gz
+      fail=$?
+      if [ $fail = 1 ]
+      then
+        dialog --msgbox "Error\n The database restore failed.  Please report." 10 50
+        goback=1
+      else
+        echo "nsconfig restore"
+      fi
+    fi  
+  fi
+fi
 done
  

--- a/restoremongo.sh
+++ b/restoremongo.sh
@@ -13,7 +13,7 @@ fi
 
 echo "$File"
 
-if [ "$(file -b "$File")" = "directory" ]
+if [ "$(file -b "$File")" = "directory" ] # If no file has been selected.
 then
   clear
   dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
@@ -24,7 +24,7 @@ fi
 
 if [ $goback -eq 0 ]
 then
-  if [ "$(file -b "$File" | awk '{print $2}')" = "tar" ]
+  if [ "$(file -b "$File" | awk '{print $2}')" = "tar" ] # If the backup is a tar file, we know it is a new backup containing both database and variables.
   then
     if [ ! "$(tar -tf $File 'database.gz')" = "database.gz" ] || [ ! "$(tar -tf $File 'nsconfig')" = "nsconfig" ]
     then
@@ -73,14 +73,23 @@ esac
         if [ $fail = 1 ]
         then
           dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nThe database import failed.  Please report." 8 50
-        else
-          dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nDatabase has been imported." 8 50
+        else # If the database was successfully imported
+          echo -e "Restored MongoDB     $(date)\n" | cat - /xDrip/Logs > /tmp/Logs
+          sudo /bin/cp -f /tmp/Logs /xDrip/Logs
+          if [ $var -lt 1 ] # If the user chose not to restore the variables
+          then
+            dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nDatabase has been imported.\nThe variables will not be restored.  But, you can view them at /tmp/nsconfig." 9 50
+          else # If the user chose to also restore the variables
+            dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nDatabase has been imported." 9 50
+          fi
         fi
       fi
       
       if [ $var -eq 1 ]
       then
         sudo cp -f nsconfig /etc/nsconfig
+        echo -e "Restored variables     $(date)\n" | cat - /xDrip/Logs > /tmp/Logs
+        sudo /bin/cp -f /tmp/Logs /xDrip/Logs
         clear
         dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nThe variables have been restored from backup.  You need to restart the server for the updated variables to take effect." 9 50
       fi
@@ -91,7 +100,7 @@ fi
 
 if [ $goback -eq 0 ]
 then
-  if [ "$(file -b "$File" | awk '{print $1}')" = "gzip" ]
+  if [ "$(file -b "$File" | awk '{print $1}')" = "gzip" ] # If the backup file is a gzip file, we will know that it is an old backup only containing the database.
   then
     dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
 The backup only contains a database.  Press enter to import it." 9 50
@@ -109,6 +118,8 @@ The backup only contains a database.  Press enter to import it." 9 50
       exit
     else
       dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nDatabase has been imported." 8 50
+      echo -e "Restored MongoDB     $(date)\n" | cat - /xDrip/Logs > /tmp/Logs
+      sudo /bin/cp -f /tmp/Logs /xDrip/Logs
       exit
     fi
   fi

--- a/restoremongo.sh
+++ b/restoremongo.sh
@@ -73,6 +73,8 @@ esac
         if [ $fail = 1 ]
         then
           dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nThe database import failed.  Please report." 8 50
+        else
+          dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nDatabase restore is complete.  Press enter to proceed." 8 50
         fi
       fi
       

--- a/restoremongo.sh
+++ b/restoremongo.sh
@@ -94,7 +94,7 @@ then
   if [ "$(file -b "$File" | awk '{print $1}')" = "gzip" ]
   then
     dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
-The backup only contains a database.  Press enter to import it." 11 50
+The backup only contains a database.  Press enter to import it." 9 50
     key=$?
     if [ $key = 255 ]
     then

--- a/restoremongo.sh
+++ b/restoremongo.sh
@@ -13,7 +13,7 @@ fi
 
 echo "$File"
 
-if [ file -b "$File" = "directory" ]
+if [ "$(file -b "$File")" = "directory" ]
 then
   dialog --msgbox "Error\n\
 You need to move the cursor over the filename\n\

--- a/restoremongo.sh
+++ b/restoremongo.sh
@@ -28,7 +28,7 @@ then
   then
     if [ ! "$(tar -tf $File 'database.gz')" = "database.gz" ] || [ ! "$(tar -tf $File 'nsconfig')" = "nsconfig" ]
     then
-      dialog --msgbox "Error\n The backup file may be corrupt.  Please report." 10 50
+      dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nThe backup file may be corrupt.  Please report." 10 50
       goback=1 # Don't execute the rest of the loop
     fi
     if [ $goback -eq 0 ]
@@ -39,13 +39,20 @@ then
       cd /tmp
       mongorestore --gzip --archive=database.gz
       fail=$?
+      clear
       if [ $fail = 1 ]
       then
-        dialog --msgbox "Error\n The database restore failed.  Please report." 8 50
+        dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nThe database import failed.  Please report." 8 50
         goback=1
       else
-        echo "nsconfig restore"
-        goback=1
+        dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nThe database import is complete.  Press enter to also restore Nightscout variables from the backup.  Or, press escape not to." 10 50
+        key=$?
+        if [ $key = 255 ]
+        then
+          exit
+        fi
+        sudo cp -f nsconfig /etc/nsconfig
+        exit
       fi
     fi  
   fi
@@ -56,14 +63,17 @@ then
   if [ "$(file -b "$File" | awk '{print $1}')" = "gzip" ]
   then
     mongorestore --gzip --archive=$File
+    clear
     fail=$?
     if [ $fail -eq 1 ]
     then
-      clear
       dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
 You need to move the cursor over the filename in the right pane and press space so that it is shown in the field at the bottom. Then, press enter.\n\
 Please try again." 11 50
       goback=1
+    else
+      dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\Imported the backed up database." 11 50
+      exit
     fi
   fi
 fi

--- a/restoremongo.sh
+++ b/restoremongo.sh
@@ -3,7 +3,7 @@
 while :
 do
 goback=0 # Reset the loop
-File=$(dialog --title "Select the backup file to restore" --fselect ~/ 10 50 3>&1 1>&2 2>&3)
+File=$(dialog --title "Select the backup file to restore" --fselect ~/ 11 50 3>&1 1>&2 2>&3)
 key=$?
 
 if [ $key = 255 ] || [ $key = 1 ]

--- a/restoremongo.sh
+++ b/restoremongo.sh
@@ -13,6 +13,12 @@ exit
 fi
 
 echo "$File"
+
+if [ "$(file -b e3rfd | awk '{print $2}')" = "tar" = "tar" ]
+then
+  tar -xf $File -C /tmp/.
+fi
+
 mongorestore --gzip --archive=$File
 fail=$?
 if [ $fail = 1 ]

--- a/update_packages.sh
+++ b/update_packages.sh
@@ -66,5 +66,7 @@ then
 fi  
 
 # Add log
-sudo sh -c 'echo -e "The packages have been installed     $(date)\n" >> /xDrip/Logs'
+rm -rf /tmp/Logs
+echo -e "The packages have been installed     $(date)\n" | cat - /xDrip/Logs > /tmp/Logs
+sudo /bin/cp -f /tmp/Logs /xDrip/Logs
  

--- a/update_packages.sh
+++ b/update_packages.sh
@@ -6,6 +6,13 @@ echo
 
 # Let's install the missing needed packages.
 
+if [ "`id -u`" != "0" ]
+then
+  echo "Script needs root."
+  echo "Cannot continue.."
+  exit 5
+fi
+
 sudo apt-get update
 
 # vis

--- a/update_packages.sh
+++ b/update_packages.sh
@@ -67,6 +67,5 @@ fi
 
 # Add log
 rm -rf /tmp/Logs
-echo -e "The packages have been installed     $(date)\n" | cat - /xDrip/Logs > /tmp/Logs
-sudo /bin/cp -f /tmp/Logs /xDrip/Logs
+echo -e "The packages have been installed     $(date)\n" >> /xDrip/Logs
  

--- a/update_packages.sh
+++ b/update_packages.sh
@@ -66,6 +66,5 @@ then
 fi  
 
 # Add log
-rm -rf /tmp/Logs
-sudo echo -e "The packages have been installed     $(date)\n" >> /xDrip/Logs
+echo -e "The packages have been installed     $(date)\n" >> /xDrip/Logs
  

--- a/update_packages.sh
+++ b/update_packages.sh
@@ -6,13 +6,6 @@ echo
 
 # Let's install the missing needed packages.
 
-if [ "`id -u`" != "0" ]
-then
-  echo "Script needs root."
-  echo "Cannot continue.."
-  exit 5
-fi
-
 sudo apt-get update
 
 # vis
@@ -73,5 +66,5 @@ then
 fi  
 
 # Add log
-echo -e "The packages have been installed     $(date)\n" >> /xDrip/Logs
+sudo sh -c 'echo -e "The packages have been installed     $(date)\n" >> /xDrip/Logs'
  

--- a/update_packages.sh
+++ b/update_packages.sh
@@ -58,6 +58,13 @@ then
   sudo apt-get install -y nodejs
 fi 
 
+# file
+whichpack=$(which file)
+if [ "$whichpack" = "" ]
+then
+  sudo apt-get -y install file
+fi  
+
 # Add log
 rm -rf /tmp/Logs
 echo -e "The packages have been installed     $(date)\n" | cat - /xDrip/Logs > /tmp/Logs

--- a/update_packages.sh
+++ b/update_packages.sh
@@ -68,7 +68,6 @@ fi
 # The last item on the above list of packages must be verified in Status.sh to have been installed.  
 
 # Add log
-rm -rf /tmp/Logs
 echo -e "The packages have been installed     $(date)\n" | cat - /xDrip/Logs > /tmp/Logs
 sudo /bin/cp -f /tmp/Logs /xDrip/Logs
  

--- a/update_packages.sh
+++ b/update_packages.sh
@@ -65,6 +65,8 @@ then
   sudo apt-get -y install file
 fi  
 
+# The last item on the above list of packages must be verified in Status.sh to have been installed.  
+
 # Add log
 rm -rf /tmp/Logs
 echo -e "The packages have been installed     $(date)\n" | cat - /xDrip/Logs > /tmp/Logs

--- a/update_packages.sh
+++ b/update_packages.sh
@@ -67,5 +67,5 @@ fi
 
 # Add log
 rm -rf /tmp/Logs
-echo -e "The packages have been installed     $(date)\n" >> /xDrip/Logs
+sudo echo -e "The packages have been installed     $(date)\n" >> /xDrip/Logs
  


### PR DESCRIPTION
This is not a PR to merge.
I would just like you to have a look.
Please never mind the number of commits.  They will be squashed before I open the real PR.

Please let me know what you think.
  
---  
  
We need a new package:
file
It is installed by update_packages.sh.

The data submenu now looks like this.
![Screenshot 2023-02-23 222626](https://user-images.githubusercontent.com/51497406/221084855-a5b30412-45bc-4604-94f7-6c12d9a7a48c.png)

Backup also backs up the variables.  It places the variables file and the compressed MongoDB into a tar file.

If you execute restore and select a backup file, the code inspects the file (using the new executable file).  If it happens to be an old file containing a gzip file, it acts as it did before after informing the user.  So, backup files created with older platforms can still be restored.

But, if the file contains a tar file, it shows the following menu.
![Screenshot 2023-02-23 222820](https://user-images.githubusercontent.com/51497406/221085241-81bf5b00-8fe1-45aa-8091-5e59f9f8d286.png)

If the user chooses to only restore the database, after restore, they will see this:
![Screenshot 2023-02-23 223234](https://user-images.githubusercontent.com/51497406/221085453-3242b2e8-98a4-433d-a9d8-141a1f15af14.png)

If restoring the variables is selected, this is what is shown after.
![Screenshot 2023-02-23 224704](https://user-images.githubusercontent.com/51497406/221087242-ea10f0c7-d76b-41b5-8144-84b549404967.png)