### PR TITLE
Backup and restore mongo and variables

### DIFF
--- a/ConfigureFreedns.sh
+++ b/ConfigureFreedns.sh
@@ -201,10 +201,6 @@ do
          sleep 60
     else
         # worked, geting out of the loop.
-        # Add log
-        rm -rf /tmp/Logs
-        echo -e "FreeDNS setup completed     $(date)\n" | cat - /xDrip/Logs > /tmp/Logs
-        sudo /bin/cp -f /tmp/Logs /xDrip/Logs
         exit 1
     fi
 done

--- a/Status.sh
+++ b/Status.sh
@@ -113,8 +113,9 @@ cert="Valid"
 fi
 
 # Verify that the latest added package has been installed
+# The utility must be the last added utility to the update_packages.sh file.
 Missing=""
-if [ "$(which qrencode)" = "" ]
+if [ "$(which file)" = "" ]
 then
   Missing="\Zb\Z1Missing packages  \Zn"
 fi
@@ -139,7 +140,7 @@ Disk size: $disksz        $DiskUsedPercent used \n\
 Ubuntu: $ubuntu \n\
 HTTP & HTTPS:  $http \n\
 ------------------------------------------ \n\
-Nightscout on Google Cloud: 2023.02.19\n\
+Nightscout on Google Cloud: 2023.02.28\n\
 $Missing $Phase1 \n\n\
 /$uname/$repo/$branch\n\
 Swap: $swap \n\

--- a/backupmongo.sh
+++ b/backupmongo.sh
@@ -18,18 +18,21 @@ fi
 
 if [ -s $Filename ]
 then
-dialog --exit-label "Try again" --msgbox "A file with the same name exists.\n\
-Choose a different filename." 7 37
+dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\n\
+A file with the same name exists.\n\
+Choose a different filename." 9 50
 clear
 else
-mongodump --gzip --archive=$Filename
+mongodump --gzip --archive=/tmp/database.gz
 exec 3>&-
-dialog --msgbox "Backup is complete.\n\
-However, it is on the same virtual machine as\n\
-your MongoDB.\n\
-It's best to download the file to your computer\n\
-for safekeeping.\n\
-See the guide for how to download." 10 51
+cd /tmp
+cp /etc/nsconfig .
+tar -cf ~/$Filename database.gz nsconfig
+
+dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\n\
+Backup is complete.\n\
+However, it is on the same virtual machine that your database and variables are on.  It's best to download the file to your computer for safekeeping.\n\
+See the guide for how to download." 13 50
 clear
 exit
 fi

--- a/menu_Data.sh
+++ b/menu_Data.sh
@@ -10,8 +10,8 @@ Choice=$(dialog --colors --nocancel --nook --menu "\
 Use the arrow keys to move the cursor.\n\
 Press Enter to execute the highlighted option.\n" 14 50 4\
  "1" "Copy data from another Nightscout"\
- "2" "Backup MongoDB"\
- "3" "Restore MongoDB"\
+ "2" "Backup MongoDB and variables"\
+ "3" "Restore MongoDB and/or variables"\
  "4" "Return"\
  3>&1 1>&2 2>&3)
 

--- a/restoremongo.sh
+++ b/restoremongo.sh
@@ -2,34 +2,132 @@
 
 while :
 do
-File=$(dialog --title "Select the backup file to restore" --fselect ~/ 10 50 3>&1 1>&2 2>&3)
-
+goback=0 # Reset the loop
+File=$(dialog --title "Select the backup file for restore" --fselect ~/ 10 50 3>&1 1>&2 2>&3)
 key=$?
 
 if [ $key = 255 ] || [ $key = 1 ]
 then
-clear
-exit
+  exit
 fi
 
 echo "$File"
-mongorestore --gzip --archive=$File
-fail=$?
-if [ $fail = 1 ]
+
+if [ "$(file -b "$File")" = "directory" ] # If no file has been selected.
 then
-dialog --msgbox "Error\n\
-You need to move the cursor over the filename\n\
-in the right pane and press space so that it\n\
-is shown in the field at the bottom.\n\
-Then, move the cursor over OK and press enter." 10 50
-else
-clear
-# Add log
-rm -rf /tmp/Logs
-echo -e "Mongo restore     $(date)\n" | cat - /xDrip/Logs > /tmp/Logs
-sudo /bin/cp -f /tmp/Logs /xDrip/Logs
-exit
+  clear
+  dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
+You need to move the cursor over the filename in the right pane and press space so that it is shown in the field at the bottom. Then, press enter.\n\
+Please try again." 11 50
+goback=1 # Don't execute the remaining part of the loop
 fi
 
+if [ $goback -eq 0 ]
+then
+  if [ "$(file -b "$File" | awk '{print $2}')" = "tar" ] # If the backup is a tar file, we know it is a new backup containing both database and variables.
+  then
+    if [ ! "$(tar -tf $File 'database.gz')" = "database.gz" ] || [ ! "$(tar -tf $File 'nsconfig')" = "nsconfig" ]
+    then
+      dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nThe backup file may be corrupt.  Please report." 10 50
+      goback=1 # Don't execute the rest of the loop
+    fi
+    if [ $goback -eq 0 ]
+    then
+      rm -f /tmp/nsconfig
+      rm -f /tmp/database.gz
+      tar -xf $File -C /tmp/.
+      cd /tmp
+      clear
+      Choice=$(dialog --colors --nocancel --nook --menu "\
+        \Zr Developed by the xDrip team \Zn\n\n\
+Use the arrow keys to move the cursor.\n\
+Press Enter to execute the highlighted option.\n" 14 50 4\
+ "1" "Restore MongoDB only"\
+ "2" "Restore variables only"\
+ "3" "Restore MongoDB and variables"\
+ "4" "Exit"\
+ 3>&1 1>&2 2>&3)
+      
+      db=0
+      var=0;
+case $Choice in
+      
+1)
+db=1
+;;
+      
+2)
+var=1
+;;
+      
+3)
+db=1
+var=1
+;;
+
+4)
+exit
+;;
+      
+esac
+      
+      if [ $db -eq 1 ] # If the user chose to restore MongoDB
+      then
+        mongorestore --gzip --archive=database.gz
+        fail=$?
+        if [ $fail = 1 ]
+        then
+          dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nThe database import failed.  Please report." 8 50
+        else # If the database was successfully imported
+          echo -e "Restored MongoDB     $(date)\n" | cat - /xDrip/Logs > /tmp/Logs
+          sudo /bin/cp -f /tmp/Logs /xDrip/Logs
+          if [ $var -lt 1 ] # If the user chose not to restore the variables
+          then
+            dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nDatabase has been imported.\nThe variables will not be restored.  But, you can view them at /tmp/nsconfig." 9 50
+          else # If the user chose to also restore the variables
+            dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nDatabase has been imported." 8 50
+          fi
+        fi
+      fi
+      
+      if [ $var -eq 1 ]
+      then
+        sudo cp -f nsconfig /etc/nsconfig
+        echo -e "Restored variables     $(date)\n" | cat - /xDrip/Logs > /tmp/Logs
+        sudo /bin/cp -f /tmp/Logs /xDrip/Logs
+        clear
+        dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nThe variables have been restored from backup.  You need to restart the server for the updated variables to take effect." 9 50
+      fi
+      exit
+    fi  
+  fi
+fi
+
+if [ $goback -eq 0 ]
+then
+  if [ "$(file -b "$File" | awk '{print $1}')" = "gzip" ] # If the backup file is a gzip file, we will know that it is an old backup only containing the database.
+  then
+    dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
+The backup only contains a database.  Press enter to import it." 9 50
+    key=$?
+    if [ $key = 255 ]
+    then
+      exit
+    fi
+    mongorestore --gzip --archive=$File
+    clear
+    fail=$?
+    if [ $fail -eq 1 ]
+    then
+      dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nDatabase import failed.  Please report." 11 50
+      exit
+    else
+      dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nDatabase has been imported." 8 50
+      echo -e "Restored MongoDB     $(date)\n" | cat - /xDrip/Logs > /tmp/Logs
+      sudo /bin/cp -f /tmp/Logs /xDrip/Logs
+      exit
+    fi
+  fi
+fi
 done
  

--- a/restoremongo.sh
+++ b/restoremongo.sh
@@ -28,6 +28,7 @@ then
   then
     if [ ! "$(tar -tf $File 'database.gz')" = "database.gz" ] || [ ! "$(tar -tf $File 'nsconfig')" = "nsconfig" ]
     then
+      clear
       dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nThe backup file may be corrupt.  Please report." 10 50
       goback=1 # Don't execute the rest of the loop
     fi
@@ -75,6 +76,7 @@ esac
       then
         mongorestore --gzip --archive=database.gz
         fail=$?
+        clear
         if [ $fail = 1 ]
         then
           dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nThe database import failed.  Please report." 8 50
@@ -107,6 +109,7 @@ if [ $goback -eq 0 ]
 then
   if [ "$(file -b "$File" | awk '{print $1}')" = "gzip" ] # If the backup file is a gzip file, we will know that it is an old backup only containing the database.
   then
+    clear
     dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
 The backup only contains a database.  Press enter to import it." 9 50
     key=$?

--- a/update_packages.sh
+++ b/update_packages.sh
@@ -58,8 +58,16 @@ then
   sudo apt-get install -y nodejs
 fi 
 
+# file
+whichpack=$(which file)
+if [ "$whichpack" = "" ]
+then
+  sudo apt-get -y install file
+fi  
+
+# The last item on the above list of packages must be verified in Status.sh to have been installed.  
+
 # Add log
-rm -rf /tmp/Logs
 echo -e "The packages have been installed     $(date)\n" | cat - /xDrip/Logs > /tmp/Logs
 sudo /bin/cp -f /tmp/Logs /xDrip/Logs
  


### PR DESCRIPTION
We need a new package:
file
It is installed by update_packages.sh.

The data submenu now looks like this.
![Screenshot 2023-02-23 222626](https://user-images.githubusercontent.com/51497406/221084855-a5b30412-45bc-4604-94f7-6c12d9a7a48c.png)

Backup also backs up the variables.  It places the variables file and the compressed MongoDB dump file into a tar file.

If you execute restore and select a backup file, the code inspects the file (using the new executable file).  If it happens to be an old file containing a gzip file, it acts as it did before after informing the user.  So, backup files created with older platforms can still be restored.

But, if the file contains a tar file, it shows the following menu.
![Screenshot 2023-02-23 222820](https://user-images.githubusercontent.com/51497406/221085241-81bf5b00-8fe1-45aa-8091-5e59f9f8d286.png)

If the user chooses to only restore the database, after restore, they will see this:
![Screenshot 2023-02-23 223234](https://user-images.githubusercontent.com/51497406/221085453-3242b2e8-98a4-433d-a9d8-141a1f15af14.png)

If restoring the variables is selected, this is what is shown after.
![Screenshot 2023-02-23 224704](https://user-images.githubusercontent.com/51497406/221087242-ea10f0c7-d76b-41b5-8144-84b549404967.png)

This has been tested.
If you want to test it, youcan simply copy the 6 changed files from the source repository and overwrite the ones in your test VM.