### PR TITLE
Remove QR code from the variables page

### DIFF
--- a/ConfigServer/variables/templates/table.html
+++ b/ConfigServer/variables/templates/table.html
@@ -212,11 +212,6 @@
             <input id="addBtn" name="Add" type="submit" value="Add new key" disabled="disabled">
         </span>
 
-    <button id="toggle_qr" type="button" onclick="toggleQR()"> Click Here for QR configartion code</button>
-    <div style="display:none" id="QR_div" class="qr-img">
-        {{ svg|safe }}
-    </div>
-
     <button type="button" id="toggleTBL"onclick="toggleTbl()">Click Here To show some useful keys</button>
 
         <table id="pos_keys_tbl" style="width:100%; display:none;">

--- a/ConfigServer/variables/templates/table.html
+++ b/ConfigServer/variables/templates/table.html
@@ -254,18 +254,6 @@
             btn.disabled = false;
             document.getElementById("addBtn").click();
         }
-        function toggleQR() {
-            var x = document.getElementById("QR_div");
-            var btn = document.getElementById("toggle_qr");
-            if (x.style.display == "none") {
-                btn.innerHTML = "Click Here to Hide QR code"
-                x.style.display = "block";
-            } else {
-                x.style.display = "none";
-                btn.innerHTML = "Click Here for QR configartion code"
-
-            }
-        }
         function toggleChange(){
             var modal = document.getElementById("myModal");
             if (modal.style.display == "none" || modal.style.display == "" )


### PR DESCRIPTION
We now have a QR code function for setting up xDrip as an uploader.  It is on the xDrip setup submenu.

We also have it on the variables setup through a web page.  But, setting up xDrip as an uploader is not related to variables.
I hope we can agree that we can remove it from the variables page to avoid having redundant functions.

I have tested this.
If you want to test it, all you need to do is to overwrite the changed file on your virtual machine with the one from this PR.  Then, if you go back to the menu and choose "Edit variables using a web browser" from the Nightscout setup submenu, you will see the new behavior.
All it does is to remove the button that brings up the QR code from the page as shown below.
![Screenshot 2023-03-08 153435](https://user-images.githubusercontent.com/51497406/223843871-45630dff-bb31-4b1a-87a8-091bd8b47eca.png)