### PR TITLE
Single quotes

### DIFF
--- a/ConfigureFreedns.sh
+++ b/ConfigureFreedns.sh
@@ -19,7 +19,7 @@ do
 go_back=0
 clear
 exec 3>&1
-Values=$(dialog --colors --ok-label "Submit" --form "     \Zr Developed by the xDrip team \Zn\n\n\n\
+Values=$(dialog --colors --ok-label "Submit" --form "       \Zr Developed by the xDrip team \Zn\n\n\n\
 Enter your FreeDNS userID and password." 12 50 0 "User ID:" 1 1 "$user" 1 14 25 0 "Password:" 2 1 "$pass" 2 14 25 0 2>&1 1>&3)
 response=$?
 if [ $response = 255 ] || [ $response = 1 ] # cancled or escaped
@@ -34,7 +34,7 @@ pass=$(echo "$Values" | sed -n 2p)
 
 if [[ "$user" =~ [A-Z] ]]
 then
-dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\
+dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
 Your FreeDNS user ID does not contain uppercase letters.  Even though FreeDNS does not inform you, it converts all uppercase letters to lowercase in your user ID.\n\n\
 If you log into FreeDNS and go to the main menu, you can see your approved user ID at the top in the right pane.\n\n\
 Please try again." 16 50
@@ -47,8 +47,8 @@ if [ "$user" = "" ] || [ "$pass" = "" ] #  At least one parameter is blank.
 then
   go_back=1
   clear
-  dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\
-  You need to enter both userID and password.  Try again."  8 50
+  dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
+You need to enter both userID and password.  Try again."  8 50
 fi
 clear
 
@@ -61,7 +61,7 @@ then
   wget -O /tmp/hosts "$arg"
 if [ ! "`grep 'Could not authenticate' /tmp/hosts`" = "" ] # Failed to log in
 then
-  dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\nFailed to authenticate.  Try again."  8 50
+  dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nFailed to authenticate.  Try again."  7 50
   go_back=1
 fi
 
@@ -70,14 +70,14 @@ then
   Lines=$(awk 'END{print NR}' /tmp/hosts)
   if [ $Lines -eq 0 ] # No hostnames # if 5
   then
-    dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\nNo subdomains found.  Ensure you have one in your Free DNS account, and try again."  9 50
+    dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nNo subdomains found.  Ensure you have one in your Free DNS account, and try again."  8 50
     go_back=1
 
   elif [ $Lines -gt 1 ] # More than one hostname
   then
     clear
     exec 3>&1
-    subvalue=$(dialog --colors --ok-label "Submit" --form "     \Zr Developed by the xDrip team \Zn\n\n\nYou have more than one subdomain.  Enter the subdomain you want to use. \nIt should look like mine.strangled.net"  12 50 0 "Subdomain:" 1 1 "$subd" 1 14 25 0 2>&1 1>&3)
+    subvalue=$(dialog --colors --ok-label "Submit" --form "       \Zr Developed by the xDrip team \Zn\n\n\nYou have more than one subdomain.  Enter the subdomain you want to use. \nIt should look like mine.strangled.net"  12 50 0 "Subdomain:" 1 1 "$subd" 1 14 25 0 2>&1 1>&3)
     response2=$?
     if [ $response2 = 255 ] || [ $response2 = 1 ] # canceled or escaped
     then
@@ -92,7 +92,7 @@ then
       then
         go_back=1
         clear
-        dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\nYou need to enter a subdomain.  Try again."  8 50
+        dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nYou need to enter a subdomain.  Try again."  7 50
       fi
 
       if [ $go_back -lt 1 ] # if 3
@@ -101,7 +101,7 @@ then
         if [ ! -s /tmp/FullLine ] # Not found
         then
           go_back=1
-          dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\nThe subdomain you entered is not one of the ones we found.  Try again." 9 50
+          dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\nThe subdomain you entered is not one of the ones we found.  Try again." 9 50
         fi
         if [ $go_back -lt 1 ]  # if 2
         then
@@ -109,7 +109,7 @@ then
         if [ $Lines2 -gt 1 ] # More than one found  if 1
         then
           go_back=1
-          dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\nThe value you entered matches more than one of your subdomains.  Try again and enter a unique value." 11 50
+          dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\nThe value you entered matches more than one of your subdomains.  Try again and enter a unique value." 10 50
         else
           FLine=$(</tmp/FullLine)
           got_them=1 # We have the hostname and direct URL
@@ -153,7 +153,7 @@ if ! grep -q "DIRECTURL" /etc/rc.local; then
     echo wget -O /tmp/freedns.txt --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 \$DIRECTURL >>  /etc/rc.local
 fi
 
-dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\
+dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
 Press enter to proceed.  Please be patient as it may take up to 10 minutes to complete." 8 50
 clear
 # wait for the ip to be updated. This might take up to 10 minutes.
@@ -176,8 +176,8 @@ while : ; do
     if [ $cnt -gt 20 ]
     then
       clear
-      dialog --colors --msgbox "    \Zr Developed by the xDrip team \Zn\n\n\
-      Please close this window.  Open a new SSH terminal.  Run FreeDNS Setup again to complete FreeDNS setup." 12 50
+      dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
+Please close this window.  Open a new SSH terminal.  Run FreeDNS Setup again to complete FreeDNS setup." 9 50
       exit
     fi
 done
@@ -208,5 +208,5 @@ cat > /tmp/FreeDNS_Failed << EOF
 Internal error.  Must run FreeDNS again.
 EOF
 
-dialog --colors --msgbox "        \Zr Developed by the xDrip team \Zn\n\nInternal error.  Press enter to exit.  Then, run \"Install Nightscout phase 2\" again." 8 50
+dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nInternal error.  Press enter to exit.  Then, run \"Install Nightscout phase 2\" again." 8 50
  

--- a/NS_Install2.sh
+++ b/NS_Install2.sh
@@ -151,7 +151,7 @@ screen -dmS nightscout sudo -u nobody bash /etc/nightscout-start.sh
 service nginx start
 EOF
 
- chmod a+x /etc/rc.local
+chmod a+x /etc/rc.local
 
 cat > /etc/systemd/system/rc-local.service << "EOF"
 [Unit]

--- a/NS_Install2.sh
+++ b/NS_Install2.sh
@@ -100,8 +100,8 @@ clear
 exec 3>&1
 Value=$(dialog --colors --ok-label "Submit" --form "       \Zr Developed by the xDrip team \Zn\n\n\n\
 Your current API_SECRET is $cs\n\n\
-You can press escape to maintain the existing one.  Or, enter a new one with at least 12 characters excluding the following.\n\n\
-$ \" \\\n " 19 50 0 "API_SECRET:" 1 1 "$secr" 1 14 25 0 2>&1 1>&3)
+You can press escape to keep it unchanged.  Or, enter a new one with at least 12 characters excluding the following.\n\n\
+$  \"  '  \\ \n " 19 50 0 "API_SECRET:" 1 1 "$secr" 1 14 25 0 2>&1 1>&3)
 response=$?
 if [ $response = 255 ] || [ $response = 1 ] # cancled or escaped
 then
@@ -122,12 +122,12 @@ clear
 
 if [ $go_back -lt 1 ]
 then
-  if [[ $ns == *[\$]* ]] || [[ $ns == *[\"]* ]] || [[ $ns == *[\\]* ]] # Reject if submission contains unacceptable characters.
+  if [[ $ns == *[\$]* ]] || [[ $ns == *[\"]* ]] || [[ $ns == *[\']* ]] || [[ $ns == *[\\]* ]] # Reject if submission contains unacceptable characters.
   then
     go_back=1
     clear
     dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
-API_SECRET should not include $, \" or \\.  Please try again."  8 50
+API_SECRET should not include $, \\, ' or \".  Please try again."  8 50
   else
     got_it=1
   fi
@@ -151,7 +151,7 @@ screen -dmS nightscout sudo -u nobody bash /etc/nightscout-start.sh
 service nginx start
 EOF
 
-chmod a+x /etc/rc.local
+ chmod a+x /etc/rc.local
 
 cat > /etc/systemd/system/rc-local.service << "EOF"
 [Unit]

--- a/NS_Install2.sh
+++ b/NS_Install2.sh
@@ -7,8 +7,8 @@ echo
 if [ "$(node -v)" = "" ] # If Node.js is not installed
 then
 clear
-dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\
-You need to complete installation phase 1 first." 9 50
+dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
+You need to complete install Nightscout phase 1 first." 9 50
 exit
 fi
 
@@ -43,18 +43,18 @@ echo
 echo "Setting up startup service"
 echo
 
-if [ ! -s /etc/nsconfig ] # Only if nsconfig does not exist already
+if [ ! -s /etc/nsconfig ] # Create a new nsconfig file only if one does not exit already.
 then
 
 cat > /etc/nsconfig << EOF
 
-export API_SECRET="YOUR_API_SECRET_HERE"
-export ENABLE="careportal food boluscalc bwp cob bgi pump openaps rawbg iob upbat cage sage basal"
-export AUTH_DEFAULT_ROLES="denied"
-export PUMP_FIELDS="reservoir battery clock"
-export DEVICESTATUS_ADVANCED="true"
-export THEME="colors"
-export DBSIZE_MAX="20000"
+export API_SECRET='YOUR_API_SECRET_HERE'
+export ENABLE='careportal food boluscalc bwp cob bgi pump openaps rawbg iob upbat cage sage basal'
+export AUTH_DEFAULT_ROLES='denied'
+export PUMP_FIELDS='reservoir battery clock'
+export DEVICESTATUS_ADVANCED='true'
+export THEME='colors'
+export DBSIZE_MAX='20000'
 
 EOF
 
@@ -84,31 +84,60 @@ sleep 10
 done
 EOF
 
-cs=`grep 'API_SECRET=' /etc/nsconfig | head -1 | cut -f2 -d'"'`
-
-echo "Current API secret is: $cs"
-echo
-echo "If you would like to change it please enter the new secret now or hit enter to leave the same"
-
-for j in {1..1000}
-do
-read -t 0.001 dummy
-done
-read -p "New secret 12 character minimum length (blank to skip change) : " ns
-
-if [ "$ns" != "" ]
+cs2=`grep 'API_SECRET=' /etc/nsconfig | cut -s -f2 -d'"'` # This is API_SECRET if double quotes are used in nsconfig.
+cs1=`grep 'API_SECRET=' /etc/nsconfig | cut -s -f2 -d\'` # This is API_SECRET if single quotes are used in nsconfig.
+cs="$cs2"
+if [ "$cs2" = "" ]
 then
-while [ ${#ns} -lt 12 ] && [ "$ns" != "" ]
-do
-read -p "Needs to be at least 12 chars - try again: " ns
-done
-if [ "$ns" != "" ]
-then
-sed -i -e "s/API_SECRET=\".*/API_SECRET=\"${ns}\"/g" /etc/nsconfig
-echo
-echo "Secret changed to: ${ns}"
-sleep 3
+  cs="$cs1" # This is the current secret (API_SECRET) from nsconfig.
 fi
+
+got_it=0
+while [ $got_it -lt 1 ]
+do
+go_back=0
+clear
+exec 3>&1
+Value=$(dialog --colors --ok-label "Submit" --form "       \Zr Developed by the xDrip team \Zn\n\n\n\
+Your current API_SECRET is $cs\n\n\
+You can press escape to maintain the existing one.  Or, enter a new one with at least 12 characters excluding the following.\n\n\
+$ \" \\\n " 19 50 0 "API_SECRET:" 1 1 "$secr" 1 14 25 0 2>&1 1>&3)
+response=$?
+if [ $response = 255 ] || [ $response = 1 ] # cancled or escaped
+then
+  ns="$cs"
+else 
+  ns=$(echo "$Value" | sed -n 1p)
+fi
+exec 3>&-
+
+if [ ${#ns} -lt 12 ] # Reject if the submission has less than 12 characters.
+then
+  go_back=1
+  clear
+  dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
+API_SECRET should have at least 12 characters.  Please try again."  8 50
+fi
+clear
+
+if [ $go_back -lt 1 ]
+then
+  if [[ $ns == *[\$]* ]] || [[ $ns == *[\"]* ]] || [[ $ns == *[\\]* ]] # Reject if submission contains unacceptable characters.
+  then
+    go_back=1
+    clear
+    dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
+API_SECRET should not include $, \" or \\.  Please try again."  8 50
+  else
+    got_it=1
+  fi
+fi
+
+done
+
+if [ "$ns" != "$cs" ] # Only if the new secret is different than the current secret (API_SECRET)
+then
+  sed -i -e "s/API_SECRET=.*/API_SECRET=\'${ns}\'/g" /etc/nsconfig # Replace API_SECRET in nsconfig with the new one using single quotes.
 fi
 
 cat > /etc/rc.local << "EOF"
@@ -122,7 +151,7 @@ screen -dmS nightscout sudo -u nobody bash /etc/nightscout-start.sh
 service nginx start
 EOF
 
-chmod a+x /etc/rc.local
+ chmod a+x /etc/rc.local
 
 cat > /etc/systemd/system/rc-local.service << "EOF"
 [Unit]
@@ -154,7 +183,7 @@ rm -rf /tmp/Logs
 echo -e "Installation phase 2 completed     $(date)\n" | cat - /xDrip/Logs > /tmp/Logs
 sudo /bin/cp -f /tmp/Logs /xDrip/Logs
 
-dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\
+dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
 Press enter to restart the server.  This will result in an expected error message.  Wait 30 seconds before clicking on retry to reconnect or using a browser to access your Nightscout." 10 50
 sudo reboot
 fi

--- a/Status.sh
+++ b/Status.sh
@@ -140,7 +140,7 @@ Disk size: $disksz        $DiskUsedPercent used \n\
 Ubuntu: $ubuntu \n\
 HTTP & HTTPS:  $http \n\
 ------------------------------------------ \n\
-Nightscout on Google Cloud: 2023.02.28\n\
+Nightscout on Google Cloud: 2023.03.15\n\
 $Missing $Phase1 \n\n\
 /$uname/$repo/$branch\n\
 Swap: $swap \n\

--- a/Status.sh
+++ b/Status.sh
@@ -140,7 +140,7 @@ Disk size: $disksz        $DiskUsedPercent used \n\
 Ubuntu: $ubuntu \n\
 HTTP & HTTPS:  $http \n\
 ------------------------------------------ \n\
-Nightscout on Google Cloud: 2023.03.15\n\
+Nightscout on Google Cloud: 2023.03.19\n\
 $Missing $Phase1 \n\n\
 /$uname/$repo/$branch\n\
 Swap: $swap \n\

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin"
-# curl https://raw.githubusercontent.com/Navid200/cgm-remote-monitor/RemoveFreeDNS_Test/bootstrap.sh | bash
+# curl https://raw.githubusercontent.com/Navid200/cgm-remote-monitor/SingleQuotes_Test/bootstrap.sh | bash
 
 echo 
 echo "Bootstrapping the installation files - JamOrHam - Navid200"
@@ -66,7 +66,7 @@ ls > /tmp/repo
 sudo mv -f /tmp/repo .    # The repository name is now in /srv/repo
 cd "$(< repo)"
 sudo git checkout vps-dev  # ✅✅✅✅✅ Main - Uncomment before PR.
-#sudo git checkout RemoveFreeDNS_Test  # ⛔⛔⛔⛔⛔ For test - Comment out before PR.
+#sudo git checkout SingleQuotes_Test  # ⛔⛔⛔⛔⛔ For test - Comment out before PR.
 
 sudo git branch > /tmp/branch
 grep "*" /tmp/branch | awk '{print $2}' > /tmp/brnch


### PR DESCRIPTION
This PR mainly changes the behavior of the Install Nightscosut phase 2 script.

Currently, a fresh install uses double quotes in the nsconfig file.
After this PR, single quotes will be used in a new nsconfig file.

The same script also offers the user the option to change API_SECRET.  It can be used by someone who has an existing system.  In that case, the existing nsconfig file may include double quotes.  Therefore, some of the added code was needed to allow the existing API_SECRET to be recovered regardless of is single quotes are used on double quotes in the nsconfig file.

This is the new menu that asks for API_SECRET:
![Screenshot 2023-03-18 221623](https://user-images.githubusercontent.com/51497406/226150133-bdf48cf7-c0f5-4219-b2d6-bca516022b0a.png)

This is what you will see if what you enter has less than 12 characters.
![Screenshot 2023-03-15 150846](https://user-images.githubusercontent.com/51497406/225417446-cbb9e21d-2ded-455f-b536-788a8d418868.png)

This is what you will see if what you enter contains one of the three unacceptable special characters.
![Screenshot 2023-03-18 221905](https://user-images.githubusercontent.com/51497406/226150265-7c3584ea-e2d3-4d63-b367-99063731a03b.png)