### PR TITLE
FreeDNS down contingency

### DIFF
--- a/ConfigureFreedns.sh
+++ b/ConfigureFreedns.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+freedns=$(wget --spider -S "https://freedns.afraid.org/" 2>&1 | awk '/HTTP\// {print $2}') # This will be 200 if FreeDNS is up.
+
+if [ $freedns -eq 200 ]  # Run the following only if FreeDNS is up.
+then
+
 if [ "`id -u`" != "0" ]
 then
 echo "Script needs root - use sudo bash ConfigureFreedns.sh"
@@ -137,7 +142,7 @@ read -a split <<< $FLine
 hostname=${split[0],,}
 directurl=${split[2]}
 
-#create a file to store the data for the startup script.
+#create a file to store FreeDNS details.
 cat> /etc/free-dns.sh<<EOF
 #!/bin/sh
 export HOSTNAME=$hostname
@@ -146,12 +151,6 @@ EOF
 
 # Start the first update immediately
 wget -O - --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 $directurl
-
-#Add the command to renew the script to the startup url
-if ! grep -q "DIRECTURL" /etc/rc.local; then
-    echo . /etc/free-dns.sh >>  /etc/rc.local
-    echo wget -O /tmp/freedns.txt --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 \$DIRECTURL >>  /etc/rc.local
-fi
 
 dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
 Press enter to proceed.  Please be patient as it may take up to 10 minutes to complete." 8 50
@@ -209,4 +208,12 @@ Internal error.  Must run FreeDNS again.
 EOF
 
 dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nInternal error.  Press enter to exit.  Then, run \"Install Nightscout phase 2\" again." 8 50
+
+else  # If FreeDNS is down
+dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
+It seems the FreeDNS site is down.  Please try again when FreeDNS is back up." 9 50
+cat > /tmp/FreeDNS_Failed << EOF
+The FreeDNS site is down.
+EOF
+fi
  

--- a/NS_Install2.sh
+++ b/NS_Install2.sh
@@ -149,6 +149,13 @@ service snapd stop
 service mongodb start
 screen -dmS nightscout sudo -u nobody bash /etc/nightscout-start.sh
 service nginx start
+freedns=$(wget --spider -S "https://freedns.afraid.org/" 2>&1 | awk '/HTTP\// {print $2}') # This will be 200 if FreeDNS is up.
+if [ $freedns -eq 200 ]  # Run the following only if FreeDNS is up.
+then
+. /etc/free-dns.sh
+wget -O /tmp/freedns.txt --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 $DIRECTURL
+fi
+
 EOF
 
  chmod a+x /etc/rc.local

--- a/Status.sh
+++ b/Status.sh
@@ -129,6 +129,13 @@ then
   Phase1="\Zb\Z1Missing node_modules\Zn"
 fi  
 
+# Verify that Nightscout will start after a reboot even if FreeDNS is down.
+rclocal1=""
+if grep -q "DIRECTURL" /etc/rc.local
+then
+  rclocal1="\Zb\Z1Startup dependence on FreeDNS\Zn"
+fi
+
 clear
 Choice=$(dialog --colors --nocancel --nook --menu "\
         \Zr Developed by the xDrip team \Zn\n\n\
@@ -140,8 +147,8 @@ Disk size: $disksz        $DiskUsedPercent used \n\
 Ubuntu: $ubuntu \n\
 HTTP & HTTPS:  $http \n\
 ------------------------------------------ \n\
-Nightscout on Google Cloud: 2023.03.19\n\
-$Missing $Phase1 \n\n\
+Nightscout on Google Cloud: 2023.04.22\n\
+$Missing $Phase1 $rclocal1 \n\n\
 /$uname/$repo/$branch\n\
 Swap: $swap \n\
 Mongo: $mongo \n\

--- a/Status.sh
+++ b/Status.sh
@@ -130,10 +130,10 @@ then
 fi  
 
 # Verify that Nightscout will start after a reboot even if FreeDNS is down.
-rclocal1=""
-if grep -q "DIRECTURL" /etc/rc.local
+rclocal1="\Zb\Z1Startup dependence on FreeDNS\Zn"
+if grep -q "freedns -eq 200" /etc/rc.local
 then
-  rclocal1="\Zb\Z1Startup dependence on FreeDNS\Zn"
+  rclocal1=""
 fi
 
 clear
@@ -147,7 +147,7 @@ Disk size: $disksz        $DiskUsedPercent used \n\
 Ubuntu: $ubuntu \n\
 HTTP & HTTPS:  $http \n\
 ------------------------------------------ \n\
-Nightscout on Google Cloud: 2023.04.22\n\
+Nightscout on Google Cloud: 2023.04.23\n\
 $Missing $Phase1 $rclocal1 \n\n\
 /$uname/$repo/$branch\n\
 Swap: $swap \n\

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin"
-# curl https://raw.githubusercontent.com/Navid200/cgm-remote-monitor/SingleQuotes_Test/bootstrap.sh | bash
+# curl https://raw.githubusercontent.com/Navid200/cgm-remote-monitor/FreeDNSDown_Test/bootstrap.sh | bash
 
 echo 
 echo "Bootstrapping the installation files - JamOrHam - Navid200"
@@ -66,7 +66,7 @@ ls > /tmp/repo
 sudo mv -f /tmp/repo .    # The repository name is now in /srv/repo
 cd "$(< repo)"
 sudo git checkout vps-dev  # ✅✅✅✅✅ Main - Uncomment before PR.
-#sudo git checkout SingleQuotes_Test  # ⛔⛔⛔⛔⛔ For test - Comment out before PR.
+#sudo git checkout FreeDNSDown_Test  # ⛔⛔⛔⛔⛔ For test - Comment out before PR.
 
 sudo git branch > /tmp/branch
 grep "*" /tmp/branch | awk '{print $2}' > /tmp/brnch


### PR DESCRIPTION
This PR changes the behavior such that when the FreeDNS site is down, Nightscsout can still start after a reboot.

This obviously only benefits those who update their platform to this.
What that means is that if the FreeDNS site goes down again, that will not be the time to update the platform to solve the problem.
People must update while FreeDNS is up.  After that, if FreeDNS goes down, they will be protected.

After this PR, if a user updates their platform, their status page will show this.
![Screenshot 2023-04-21 164858](https://user-images.githubusercontent.com/51497406/233758952-ce8f88dd-5c11-47e5-836e-bf01ae26da1a.png)

The red note "Startup dependence on FreeDNS" will show that the system has that problem.
The guide will show that this note can be addressed by running phase 2.
After user runs phase 2, their rc.local will be rebuilt removing the dependence and the note will not show any longer on the status page.

After this PR, if a user runs ConfigFreeDNS, they will see the following dialog if the FreeDNS site is down.
![Screenshot 2023-04-21 223247](https://user-images.githubusercontent.com/51497406/233759054-5046daf0-4aa6-43a4-ba24-987fcd8b9a64.png)
