### PR TITLE
FreeDNS site failure contingency

### DIFF
--- a/ConfigureFreedns.sh
+++ b/ConfigureFreedns.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+freedns=$(wget --spider -S "https://freedns.afraid.org/" 2>&1 | awk '/HTTP\// {print $2}') # This will be 200 if FreeDNS is up.
+
+if [ $freedns -eq 200 ]  # Run the following only if FreeDNS is up.
+then
+
 if [ "`id -u`" != "0" ]
 then
 echo "Script needs root - use sudo bash ConfigureFreedns.sh"
@@ -150,7 +155,7 @@ wget -O - --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 $dire
 #Add the command to renew the script to the startup url
 if ! grep -q "DIRECTURL" /etc/rc.local; then
     echo . /etc/free-dns.sh >>  /etc/rc.local
-    echo wget -O /tmp/freedns.txt --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 \$DIRECTURL >>  /etc/rc.local
+    echo wget -O /tmp/freedns.txt --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 \$DIRECTURL \& >>  /etc/rc.local
 fi
 
 dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
@@ -209,4 +214,12 @@ Internal error.  Must run FreeDNS again.
 EOF
 
 dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nInternal error.  Press enter to exit.  Then, run \"Install Nightscout phase 2\" again." 8 50
+
+else  # If FreeDNS is down
+dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
+It seems the FreeDNS site is down.  Please try again when FreeDNS is back up." 9 50
+cat > /tmp/FreeDNS_Failed << EOF
+The FreeDNS site is down.
+EOF
+fi
  

--- a/ConfigureFreedns.sh
+++ b/ConfigureFreedns.sh
@@ -155,7 +155,8 @@ wget -O - --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 $dire
 #Add the command to renew the script to the startup url
 if ! grep -q "DIRECTURL" /etc/rc.local; then
     echo . /etc/free-dns.sh >>  /etc/rc.local
-    echo wget -O /tmp/freedns.txt --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 \$DIRECTURL \& >>  /etc/rc.local
+    echo wget -O /tmp/freedns.txt --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 \$DIRECTURL >>  /etc/rc.local
+    echo exit 0 \# This should be the last line to ensure the startup will complete. >> /etc/rc.local
 fi
 
 dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\

--- a/Status.sh
+++ b/Status.sh
@@ -129,6 +129,14 @@ then
   Phase1="\Zb\Z1Missing node_modules\Zn"
 fi  
 
+# Verify that Nightscout will start after a reboot even if FreeDNS is down.
+rclocal_1="\Zb\Z1Startup dependence on FreeDNS\Zn"
+grep '$DIRECTURL &' /etc/rc.local > /tmp/rclocal_1
+if [ -s /tmp/rclocal_1 ]
+then
+  rclocal_1=""
+fi
+
 clear
 Choice=$(dialog --colors --nocancel --nook --menu "\
         \Zr Developed by the xDrip team \Zn\n\n\
@@ -140,8 +148,8 @@ Disk size: $disksz        $DiskUsedPercent used \n\
 Ubuntu: $ubuntu \n\
 HTTP & HTTPS:  $http \n\
 ------------------------------------------ \n\
-Nightscout on Google Cloud: 2023.03.19\n\
-$Missing $Phase1 \n\n\
+Nightscout on Google Cloud: 2023.04.24\n\
+$Missing $Phase1 $rclocal_1 \n\n\
 /$uname/$repo/$branch\n\
 Swap: $swap \n\
 Mongo: $mongo \n\

--- a/Status.sh
+++ b/Status.sh
@@ -129,9 +129,9 @@ then
   Phase1="\Zb\Z1Missing node_modules\Zn"
 fi  
 
-# Verify that Nightscout will start after a reboot even if FreeDNS is down.
+# Verify that exit 0 is in rc.local so that Nightscout can start after a reboot even if FreeDNS is down.
 rclocal_1="\Zb\Z1Startup dependence on FreeDNS\Zn"
-grep '$DIRECTURL &' /etc/rc.local > /tmp/rclocal_1
+grep 'exit 0' /etc/rc.local > /tmp/rclocal_1
 if [ -s /tmp/rclocal_1 ]
 then
   rclocal_1=""
@@ -148,7 +148,7 @@ Disk size: $disksz        $DiskUsedPercent used \n\
 Ubuntu: $ubuntu \n\
 HTTP & HTTPS:  $http \n\
 ------------------------------------------ \n\
-Nightscout on Google Cloud: 2023.04.24\n\
+Nightscout on Google Cloud: 2023.04.26\n\
 $Missing $Phase1 $rclocal_1 \n\n\
 /$uname/$repo/$branch\n\
 Swap: $swap \n\

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin"
-# curl https://raw.githubusercontent.com/Navid200/cgm-remote-monitor/SingleQuotes_Test/bootstrap.sh | bash
+# curl https://raw.githubusercontent.com/Navid200/cgm-remote-monitor/FreeDNSDown_Test/bootstrap.sh | bash
 
 echo 
 echo "Bootstrapping the installation files - JamOrHam - Navid200"


### PR DESCRIPTION
The FreeDNS site was down in April 2023.  The incident lasted more than 24 hours.
During that period, any user who restarted their virtual machine, experienced an interruption of their Nightscout server operation.

This PR changes our setup such that a server restart will not cause any problems even if the FreeDNS site is down.

However, if the IP address of a virtual machine changes, and the FreeDNS site is down, we have no way of resolving the problem.  
If the FreeDNS site is down, users should keep their virtual machines up and running.  As long as they do not stop their machines, the IP will not change.  Even a restart will not cause the IP address to change.

Why did our setup fail?
My understanding is that the rc.local file is not tolerant of failed commands.  By running the command that depends on the FreeDNS site in the background, we allow it to run in a separate thread so that it would not interfere with everything else that needs to run in rc.local.

The following is an example where it is advised to add & after the command in rc.local.

https://raspberrypi.stackexchange.com/questions/9485/autostarting-program-with-rc-local-stuck-on-startup


