### PR TITLE
Upgrade to Ubuntu 20.04.6

### DIFF
--- a/Status.sh
+++ b/Status.sh
@@ -47,7 +47,7 @@ swap="$(free -h | sed -n 3p | awk '{print $2}')"
 
 #Ubuntu version
 ubuntu="$(lsb_release -a | sed -n 2p | awk '{print $3, $4}')"
-if [ ! "$ubuntu" = "20.04.5 LTS" ]
+if [ ! "$ubuntu" = "20.04.5 LTS" || ! "$ubuntu" = "20.04.6 LTS" ]
 then
 ubuntu="\Zb\Z1$(lsb_release -a | sed -n 2p | awk '{print $3, $4}')\Zn"
 fi

--- a/Status.sh
+++ b/Status.sh
@@ -47,7 +47,7 @@ swap="$(free -h | sed -n 3p | awk '{print $2}')"
 
 #Ubuntu version
 ubuntu="$(lsb_release -a | sed -n 2p | awk '{print $3, $4}')"
-if [ ! "$ubuntu" = "20.04.5 LTS" || ! "$ubuntu" = "20.04.6 LTS" ]
+if [ ! "$ubuntu" = "20.04.5 LTS" && ! "$ubuntu" = "20.04.6 LTS" ]
 then
 ubuntu="\Zb\Z1$(lsb_release -a | sed -n 2p | awk '{print $3, $4}')\Zn"
 fi

--- a/Status.sh
+++ b/Status.sh
@@ -148,7 +148,7 @@ Disk size: $disksz        $DiskUsedPercent used \n\
 Ubuntu: $ubuntu \n\
 HTTP & HTTPS:  $http \n\
 ------------------------------------------ \n\
-Nightscout on Google Cloud: 2023.05.05\n\
+Nightscout on Google Cloud: 2023.05.09\n\
 $Missing $Phase1 $rclocal_1 \n\n\
 /$uname/$repo/$branch\n\
 Swap: $swap \n\

--- a/Status.sh
+++ b/Status.sh
@@ -148,7 +148,7 @@ Disk size: $disksz        $DiskUsedPercent used \n\
 Ubuntu: $ubuntu \n\
 HTTP & HTTPS:  $http \n\
 ------------------------------------------ \n\
-Nightscout on Google Cloud: 2023.04.26\n\
+Nightscout on Google Cloud: 2023.05.05\n\
 $Missing $Phase1 $rclocal_1 \n\n\
 /$uname/$repo/$branch\n\
 Swap: $swap \n\

--- a/menu_GC_Setup.sh
+++ b/menu_GC_Setup.sh
@@ -34,7 +34,6 @@ sudo git reset --hard  # delete any local edits.
 sudo git pull  # Update database from remote.
 sudo chmod 755 update_scripts.sh
 sudo cp -f update_scripts.sh /xDrip/scripts/. # Update the "update scripts" script. 
-sudo cp -f update_packages.sh /xDrip/scripts/. # Update the "update_packages" script.
 clear
 sudo /xDrip/scripts/update_scripts.sh
 sudo /xDrip/scripts/update_packages.sh

--- a/menu_GC_Setup.sh
+++ b/menu_GC_Setup.sh
@@ -33,7 +33,8 @@ cd "$(< repo)"  # Go to the local database
 sudo git reset --hard  # delete any local edits.
 sudo git pull  # Update database from remote.
 sudo chmod 755 update_scripts.sh
-sudo cp -f update_scripts.sh /xDrip/scripts/.
+sudo cp -f update_scripts.sh /xDrip/scripts/. # Update the "update scripts" script. 
+sudo cp -f update_packages.sh /xDrip/scripts/. # Update the "update_packages" script.
 clear
 sudo /xDrip/scripts/update_scripts.sh
 sudo /xDrip/scripts/update_packages.sh

--- a/update_packages.sh
+++ b/update_packages.sh
@@ -11,7 +11,7 @@ sudo snap set system refresh.retain=2
 sudo apt-get update
 
 #Ubuntu upgrade available
-NextUbuntu="apt-get -s upgrade | grep 'Inst base' | awk '{print $4}' | sed 's/(//'"
+NextUbuntu="$(apt-get -s upgrade | grep 'Inst base' | awk '{print $4}' | sed 's/(//')"
 if [ "$NextUbuntu" = "11ubuntu5.7" ] # Only upgrade if we have tested the next release
 then
   sudo apt-get -y upgrade

--- a/update_packages.sh
+++ b/update_packages.sh
@@ -9,7 +9,13 @@ sudo snap set system refresh.retain=2
 
 # Let's upgrade packages if available and install the missing needed packages.
 sudo apt-get update
-sudo apt-get -y upgrade
+
+#Ubuntu version
+ubuntu="$(lsb_release -a | sed -n 2p | awk '{print $3, $4}')"
+if [ "$ubuntu" = "20.04.5 LTS" ] # Only upgrade if we have tested the next release
+then
+  sudo apt-get -y upgrade
+fi
 
 # vis
 whichpack=$(which vis)

--- a/update_packages.sh
+++ b/update_packages.sh
@@ -10,9 +10,9 @@ sudo snap set system refresh.retain=2
 # Let's upgrade packages if available and install the missing needed packages.
 sudo apt-get update
 
-#Ubuntu version
-ubuntu="$(lsb_release -a | sed -n 2p | awk '{print $3, $4}')"
-if [ "$ubuntu" = "20.04.5 LTS" ] # Only upgrade if we have tested the next release
+#Ubuntu upgrade available
+NextUbuntu="apt-get -s upgrade | grep 'Inst base' | awk '{print $4}' | sed 's/(//'"
+if [ "$NextUbuntu" = "11ubuntu5.7" ] # Only upgrade if we have tested the next release
 then
   sudo apt-get -y upgrade
 fi

--- a/update_packages.sh
+++ b/update_packages.sh
@@ -4,9 +4,12 @@ echo
 echo "Install packages only if they are not installed already. - Navid200"
 echo
 
-# Let's install the missing needed packages.
+# Reduce the number of snapshots kept from the default 3 to 2 to reduce disk space usage.
+sudo snap set system refresh.retain=2
 
+# Let's upgrade packages if available and install the missing needed packages.
 sudo apt-get update
+sudo apt-get -y upgrade
 
 # vis
 whichpack=$(which vis)


### PR DESCRIPTION
Google have changed the images.

Ubuntu 20.04.5 does not exist anymore.  Instead, there is 20.04.6.

This PR considers both acceptable showing them on the status page without changing the color to red.

Edit:
I went through the installation procedure and everything is working fine as far as I can see.  Nightscout is up and running.  So , I suggest that we merge this PR, which will remove the marker giving inexperienced users performing a fresh install an impression that they have done something wrong.
If in the future, we find out that something is wrong with our setup on the new version (20.04.6), we will fix it as needed.

Edit 2:
I edited the date on the status page.
Changed the update platform command such that it would fetch update_packages before executing it.
Added sudo apt-get -y upgrade to the update_packages script.  Now, those who have existing systems will be updated to the new Ubuntu when they update their platform.  So, they don't need to create a new machine.