### PR TITLE
Promote 2023.05.15 dev to stable

### DIFF
--- a/ConfigureFreedns.sh
+++ b/ConfigureFreedns.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+freedns=$(wget --spider -S "https://freedns.afraid.org/" 2>&1 | awk '/HTTP\// {print $2}') # This will be 200 if FreeDNS is up.
+
+if [ $freedns -eq 200 ]  # Run the following only if FreeDNS is up.
+then
+
 if [ "`id -u`" != "0" ]
 then
 echo "Script needs root - use sudo bash ConfigureFreedns.sh"
@@ -150,7 +155,7 @@ wget -O - --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 $dire
 #Add the command to renew the script to the startup url
 if ! grep -q "DIRECTURL" /etc/rc.local; then
     echo . /etc/free-dns.sh >>  /etc/rc.local
-    echo wget -O /tmp/freedns.txt --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 \$DIRECTURL >>  /etc/rc.local
+    echo wget -O /tmp/freedns.txt --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 \$DIRECTURL \& >>  /etc/rc.local
 fi
 
 dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
@@ -209,4 +214,12 @@ Internal error.  Must run FreeDNS again.
 EOF
 
 dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nInternal error.  Press enter to exit.  Then, run \"Install Nightscout phase 2\" again." 8 50
+
+else  # If FreeDNS is down
+dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
+It seems the FreeDNS site is down.  Please try again when FreeDNS is back up." 9 50
+cat > /tmp/FreeDNS_Failed << EOF
+The FreeDNS site is down.
+EOF
+fi
  

--- a/ConfigureFreedns.sh
+++ b/ConfigureFreedns.sh
@@ -155,7 +155,8 @@ wget -O - --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 $dire
 #Add the command to renew the script to the startup url
 if ! grep -q "DIRECTURL" /etc/rc.local; then
     echo . /etc/free-dns.sh >>  /etc/rc.local
-    echo wget -O /tmp/freedns.txt --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 \$DIRECTURL \& >>  /etc/rc.local
+    echo wget -O /tmp/freedns.txt --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 \$DIRECTURL >>  /etc/rc.local
+    echo exit 0 \# This should be the last line to ensure the startup will complete. >> /etc/rc.local
 fi
 
 dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\

--- a/Status.sh
+++ b/Status.sh
@@ -129,6 +129,14 @@ then
   Phase1="\Zb\Z1Missing node_modules\Zn"
 fi  
 
+# Verify that Nightscout will start after a reboot even if FreeDNS is down.
+rclocal_1="\Zb\Z1Startup dependence on FreeDNS\Zn"
+grep '$DIRECTURL &' /etc/rc.local > /tmp/rclocal_1
+if [ -s /tmp/rclocal_1 ]
+then
+  rclocal_1=""
+fi
+
 clear
 Choice=$(dialog --colors --nocancel --nook --menu "\
         \Zr Developed by the xDrip team \Zn\n\n\
@@ -140,8 +148,8 @@ Disk size: $disksz        $DiskUsedPercent used \n\
 Ubuntu: $ubuntu \n\
 HTTP & HTTPS:  $http \n\
 ------------------------------------------ \n\
-Nightscout on Google Cloud: 2023.03.19\n\
-$Missing $Phase1 \n\n\
+Nightscout on Google Cloud: 2023.04.24\n\
+$Missing $Phase1 $rclocal_1 \n\n\
 /$uname/$repo/$branch\n\
 Swap: $swap \n\
 Mongo: $mongo \n\

--- a/Status.sh
+++ b/Status.sh
@@ -47,7 +47,7 @@ swap="$(free -h | sed -n 3p | awk '{print $2}')"
 
 #Ubuntu version
 ubuntu="$(lsb_release -a | sed -n 2p | awk '{print $3, $4}')"
-if [ ! "$ubuntu" = "20.04.5 LTS" ]
+if [ ! "$ubuntu" = "20.04.5 LTS" || ! "$ubuntu" = "20.04.6 LTS" ]
 then
 ubuntu="\Zb\Z1$(lsb_release -a | sed -n 2p | awk '{print $3, $4}')\Zn"
 fi

--- a/Status.sh
+++ b/Status.sh
@@ -47,7 +47,7 @@ swap="$(free -h | sed -n 3p | awk '{print $2}')"
 
 #Ubuntu version
 ubuntu="$(lsb_release -a | sed -n 2p | awk '{print $3, $4}')"
-if [ ! "$ubuntu" = "20.04.5 LTS" || ! "$ubuntu" = "20.04.6 LTS" ]
+if [ ! "$ubuntu" = "20.04.5 LTS" && ! "$ubuntu" = "20.04.6 LTS" ]
 then
 ubuntu="\Zb\Z1$(lsb_release -a | sed -n 2p | awk '{print $3, $4}')\Zn"
 fi

--- a/Status.sh
+++ b/Status.sh
@@ -129,9 +129,9 @@ then
   Phase1="\Zb\Z1Missing node_modules\Zn"
 fi  
 
-# Verify that Nightscout will start after a reboot even if FreeDNS is down.
+# Verify that exit 0 is in rc.local so that Nightscout can start after a reboot even if FreeDNS is down.
 rclocal_1="\Zb\Z1Startup dependence on FreeDNS\Zn"
-grep '$DIRECTURL &' /etc/rc.local > /tmp/rclocal_1
+grep 'exit 0' /etc/rc.local > /tmp/rclocal_1
 if [ -s /tmp/rclocal_1 ]
 then
   rclocal_1=""
@@ -148,7 +148,7 @@ Disk size: $disksz        $DiskUsedPercent used \n\
 Ubuntu: $ubuntu \n\
 HTTP & HTTPS:  $http \n\
 ------------------------------------------ \n\
-Nightscout on Google Cloud: 2023.04.24\n\
+Nightscout on Google Cloud: 2023.04.26\n\
 $Missing $Phase1 $rclocal_1 \n\n\
 /$uname/$repo/$branch\n\
 Swap: $swap \n\

--- a/Status.sh
+++ b/Status.sh
@@ -148,7 +148,7 @@ Disk size: $disksz        $DiskUsedPercent used \n\
 Ubuntu: $ubuntu \n\
 HTTP & HTTPS:  $http \n\
 ------------------------------------------ \n\
-Nightscout on Google Cloud: 2023.05.05\n\
+Nightscout on Google Cloud: 2023.05.09\n\
 $Missing $Phase1 $rclocal_1 \n\n\
 /$uname/$repo/$branch\n\
 Swap: $swap \n\

--- a/Status.sh
+++ b/Status.sh
@@ -148,7 +148,7 @@ Disk size: $disksz        $DiskUsedPercent used \n\
 Ubuntu: $ubuntu \n\
 HTTP & HTTPS:  $http \n\
 ------------------------------------------ \n\
-Nightscout on Google Cloud: 2023.04.26\n\
+Nightscout on Google Cloud: 2023.05.05\n\
 $Missing $Phase1 $rclocal_1 \n\n\
 /$uname/$repo/$branch\n\
 Swap: $swap \n\

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin"
-# curl https://raw.githubusercontent.com/Navid200/cgm-remote-monitor/SingleQuotes_Test/bootstrap.sh | bash
+# curl https://raw.githubusercontent.com/Navid200/cgm-remote-monitor/FreeDNSDown_Test/bootstrap.sh | bash
 
 echo 
 echo "Bootstrapping the installation files - JamOrHam - Navid200"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -65,7 +65,7 @@ sudo git clone https://github.com/jamorham/nightscout-vps.git  # ✅✅✅✅✅
 ls > /tmp/repo
 sudo mv -f /tmp/repo .    # The repository name is now in /srv/repo
 cd "$(< repo)"
-sudo git checkout vps-dev  # ✅✅✅✅✅ Main - Uncomment before PR.
+sudo git checkout vps-1  # ✅✅✅✅✅ Main - Uncomment before PR.
 #sudo git checkout SingleQuotes_Test  # ⛔⛔⛔⛔⛔ For test - Comment out before PR.
 
 sudo git branch > /tmp/branch

--- a/menu_GC_Setup.sh
+++ b/menu_GC_Setup.sh
@@ -34,7 +34,6 @@ sudo git reset --hard  # delete any local edits.
 sudo git pull  # Update database from remote.
 sudo chmod 755 update_scripts.sh
 sudo cp -f update_scripts.sh /xDrip/scripts/. # Update the "update scripts" script. 
-sudo cp -f update_packages.sh /xDrip/scripts/. # Update the "update_packages" script.
 clear
 sudo /xDrip/scripts/update_scripts.sh
 sudo /xDrip/scripts/update_packages.sh

--- a/menu_GC_Setup.sh
+++ b/menu_GC_Setup.sh
@@ -33,7 +33,8 @@ cd "$(< repo)"  # Go to the local database
 sudo git reset --hard  # delete any local edits.
 sudo git pull  # Update database from remote.
 sudo chmod 755 update_scripts.sh
-sudo cp -f update_scripts.sh /xDrip/scripts/.
+sudo cp -f update_scripts.sh /xDrip/scripts/. # Update the "update scripts" script. 
+sudo cp -f update_packages.sh /xDrip/scripts/. # Update the "update_packages" script.
 clear
 sudo /xDrip/scripts/update_scripts.sh
 sudo /xDrip/scripts/update_packages.sh

--- a/update_packages.sh
+++ b/update_packages.sh
@@ -11,7 +11,7 @@ sudo snap set system refresh.retain=2
 sudo apt-get update
 
 #Ubuntu upgrade available
-NextUbuntu="apt-get -s upgrade | grep 'Inst base' | awk '{print $4}' | sed 's/(//'"
+NextUbuntu="$(apt-get -s upgrade | grep 'Inst base' | awk '{print $4}' | sed 's/(//')"
 if [ "$NextUbuntu" = "11ubuntu5.7" ] # Only upgrade if we have tested the next release
 then
   sudo apt-get -y upgrade

--- a/update_packages.sh
+++ b/update_packages.sh
@@ -9,7 +9,13 @@ sudo snap set system refresh.retain=2
 
 # Let's upgrade packages if available and install the missing needed packages.
 sudo apt-get update
-sudo apt-get -y upgrade
+
+#Ubuntu version
+ubuntu="$(lsb_release -a | sed -n 2p | awk '{print $3, $4}')"
+if [ "$ubuntu" = "20.04.5 LTS" ] # Only upgrade if we have tested the next release
+then
+  sudo apt-get -y upgrade
+fi
 
 # vis
 whichpack=$(which vis)

--- a/update_packages.sh
+++ b/update_packages.sh
@@ -10,9 +10,9 @@ sudo snap set system refresh.retain=2
 # Let's upgrade packages if available and install the missing needed packages.
 sudo apt-get update
 
-#Ubuntu version
-ubuntu="$(lsb_release -a | sed -n 2p | awk '{print $3, $4}')"
-if [ "$ubuntu" = "20.04.5 LTS" ] # Only upgrade if we have tested the next release
+#Ubuntu upgrade available
+NextUbuntu="apt-get -s upgrade | grep 'Inst base' | awk '{print $4}' | sed 's/(//'"
+if [ "$NextUbuntu" = "11ubuntu5.7" ] # Only upgrade if we have tested the next release
 then
   sudo apt-get -y upgrade
 fi

--- a/update_packages.sh
+++ b/update_packages.sh
@@ -4,9 +4,12 @@ echo
 echo "Install packages only if they are not installed already. - Navid200"
 echo
 
-# Let's install the missing needed packages.
+# Reduce the number of snapshots kept from the default 3 to 2 to reduce disk space usage.
+sudo snap set system refresh.retain=2
 
+# Let's upgrade packages if available and install the missing needed packages.
 sudo apt-get update
+sudo apt-get -y upgrade
 
 # vis
 whichpack=$(which vis)


### PR DESCRIPTION
We have had two PRs that have updated the development branch.

1- Allow a server restart even if the FreeDNS site is down
2- Allow Ubuntu update to 20.04.6

This PR promotes the development branch containing only those two changes to become the stable branch.
As long as we don't have the second change in the stable branch, all installations using the stable branch come up with a red marker on the status page.  