### PR TITLE
Free dns auto login

### DIFF
--- a/ConfigureFreedns.sh
+++ b/ConfigureFreedns.sh
@@ -15,7 +15,7 @@ fi
 sudo apt-get install bind9-dnsutils -y
 
 echo
-echo "Move to use free dns instead of noip.com" - tzachi-dar
+echo "Move to use free dns instead of noip.com - tzachi-dar"
 echo
 
 got_them=0
@@ -118,6 +118,15 @@ then
         else
           FLine=$(</tmp/FullLine)
           got_them=1 # We have the hostname and direct URL
+          rm -rf /xDrip/FreeDNS_ID_Pass
+cat > /xDrip/FreeDNS_ID_Pass << EOF
+#!/bin/sh
+# This file is generated automatically.  It will be deleted and recreated.
+# Please do not add anything to this file.
+export User_ID=$user
+export Password=$pass
+EOF
+          
         fi # fi 1
 
       fi # fi 2
@@ -152,13 +161,6 @@ EOF
 # Start the first update immediately
 wget -O - --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 $directurl
 
-#Add the command to renew the script to the startup url
-if ! grep -q "DIRECTURL" /etc/rc.local; then
-    echo . /etc/free-dns.sh >>  /etc/rc.local
-    echo wget -O /tmp/freedns.txt --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 \$DIRECTURL >>  /etc/rc.local
-    echo exit 0 \# This should be the last line to ensure the startup will complete. >> /etc/rc.local
-fi
-
 dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
 Press enter to proceed.  Please be patient as it may take up to 10 minutes to complete." 8 50
 clear
@@ -189,7 +191,6 @@ Please close this window.  Open a new SSH terminal.  Run FreeDNS Setup again to 
 done
 
 #Fix the certificate using the new host name.
-
 
 for i in {1..4}
 do

--- a/FreednsLogin.sh
+++ b/FreednsLogin.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+echo
+echo "Log into the FreeDNS site. - Navid200"
+echo
+
+# This could also run in the background.  So, it should contain no dialog.
+
+freedns=$(wget --spider -S "https://freedns.afraid.org/" 2>&1 | awk '/HTTP\// {print $2}') # This will be 200 if FreeDNS is up.
+if [ $freedns -eq 200 ]  # Run the following only if FreeDNS is up.
+then 
+  if [ -s /xDrip/FreeDNS_ID_Pass ] # If the FreeDNS_ID_Pass file exists
+  then
+    . /xDrip/FreeDNS_ID_Pass
+    user=$User_ID
+    pass=$Password
+    arg1="https://freedns.afraid.org/api/?action=getdyndns&v=2&sha="
+    arg2=$(echo -n "$user|$pass" | sha1sum | awk '{print $1;}')
+    arg="$arg1$arg2"
+    wget -O /tmp/hosts "$arg"
+    rm -rf /tmp/Logs
+    rm -rf /xDrip/FreeDNS_Fail
+    if [ ! "`grep 'Could not authenticate' /tmp/hosts`" = "" ] # Failed to log in
+    then
+      echo -e "Login to FreeDNS failed autherntication.      $(date)\n" | cat - /xDrip/FreeDNS_AutoLogin_Logs > /tmp/Logs
+      cat > /xDrip/FreeDNS_Fail << EOF
+FreeDNS failed authentication.
+EOF
+    else
+      echo -e "Logged into FreeDNS.      $(date)\n" | cat - /xDrip/FreeDNS_AutoLogin_Logs > /tmp/Logs
+    fi
+  else
+    # Create a log.
+    echo -e "The /xDrip/FreeDNS_ID_Pass file does not exist.      $(date)\n" | cat - /xDrip/FreeDNS_AutoLogin_Logs > /tmp/Logs
+    cat > /xDrip/FreeDNS_Fail << EOF
+FreeDNS_ID_Pass file does not exist.
+EOF
+
+  fi
+else
+  # Create a log.
+  rm -rf /tmp/Logs
+  echo -e "The FreeDNS site seems to be down.      $(date)\n" | cat - /xDrip/FreeDNS_AutoLogin_Logs > /tmp/Logs
+fi
+# Finalize the log.
+sudo /bin/cp -f /tmp/Logs /xDrip/FreeDNS_AutoLogin_Logs
+ 

--- a/NS_Install2.sh
+++ b/NS_Install2.sh
@@ -140,16 +140,7 @@ then
   sed -i -e "s/API_SECRET=.*/API_SECRET=\'${ns}\'/g" /etc/nsconfig # Replace API_SECRET in nsconfig with the new one using single quotes.
 fi
 
-cat > /etc/rc.local << "EOF"
-#!/bin/bash
-PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin"
-cd /tmp
-swapon /var/SWAP
-service snapd stop
-service mongodb start
-screen -dmS nightscout sudo -u nobody bash /etc/nightscout-start.sh
-service nginx start
-EOF
+/xDrip/scripts/StartUpSetup.sh
 
  chmod a+x /etc/rc.local
 

--- a/StartUpSetup.sh
+++ b/StartUpSetup.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+if [ "`id -u`" != "0" ]
+then
+  echo "Script needs root - use sudo bash ConfigureFreedns.sh"
+  echo "Cannot continue."
+exit 5
+fi
+
+echo
+echo "Set up startup - Navid200"
+echo
+
+if ! grep -q "/xDrip/scripts/FreednsLogin.sh" /etc/rc.local
+then
+  cat > /etc/rc.local << "EOF"
+#!/bin/bash
+# This file is generated automatically.  It will be deleted and recreated.
+# Please do not add anything to this file.
+PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin"
+cd /tmp
+swapon /var/SWAP
+service snapd stop
+service mongodb start
+screen -dmS nightscout sudo -u nobody bash /etc/nightscout-start.sh
+service nginx start
+/xDrip/scripts/FreednsLogin.sh
+. /etc/free-dns.sh
+wget -O /tmp/freedns.txt --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 $DIRECTURL
+exit 0 # This should be the last line to ensure the startup will complete.
+EOF
+
+fi

--- a/Status.sh
+++ b/Status.sh
@@ -47,7 +47,7 @@ swap="$(free -h | sed -n 3p | awk '{print $2}')"
 
 #Ubuntu version
 ubuntu="$(lsb_release -a | sed -n 2p | awk '{print $3, $4}')"
-if [ ! "$ubuntu" = "20.04.5 LTS" && ! "$ubuntu" = "20.04.6 LTS" ]
+if [ ! "$ubuntu" = "20.04.6 LTS" ]
 then
 ubuntu="\Zb\Z1$(lsb_release -a | sed -n 2p | awk '{print $3, $4}')\Zn"
 fi
@@ -137,6 +137,21 @@ then
   rclocal_1=""
 fi
 
+# Mark FreeDNS login issues.
+freedns_id=""
+freedns_pass=""
+if [ -s /xDrip/FreeDNS_ID_Pass ]
+then
+  . /xDrip/FreeDNS_ID_Pass
+  freedns_id=$User_ID
+  freedns_pass=$Password
+fi
+freedns_id_pass=""
+if [ -s /xDrip/FreeDNS_Fail ]
+then
+  freedns_id_pass="\Zb\Z5FreeDNS ID and pass\Zn"
+fi
+
 clear
 Choice=$(dialog --colors --nocancel --nook --menu "\
         \Zr Developed by the xDrip team \Zn\n\n\
@@ -148,31 +163,32 @@ Disk size: $disksz        $DiskUsedPercent used \n\
 Ubuntu: $ubuntu \n\
 HTTP & HTTPS:  $http \n\
 ------------------------------------------ \n\
-Nightscout on Google Cloud: 2023.05.09\n\
-$Missing $Phase1 $rclocal_1 \n\n\
+Google Cloud Nightscout  2023.07.17\n\
+$Missing $Phase1 $rclocal_1 $freedns_id_pass \n\n\
 /$uname/$repo/$branch\n\
 Swap: $swap \n\
 Mongo: $mongo \n\
 NS proc: $ns \n\
 FreeDNS name and IP: $FD \n\
 Certificate: $cert \
- " 29 50 2\
+ " 30 50 3\
  "1" "Return"\
- "2" "Hostname and password"\
+ "2" "Login credentials"\
  3>&1 1>&2 2>&3)
  
- case $Choice in
+case $Choice in
  
- 1)
+1)
 exit
 ;;
 
 2)
 dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
-               \Zb\Z1Keep private.\Zn\n\
-FreeDNS hostname:  $HOSTNAME\n\
-API_SECRET: $apisec" 9 50
+              \Zb\Z1Keep private!\Zn\n\n\
+Hostname:  $HOSTNAME\n\
+API_SECRET: $apisec\n\n\
+FreeDNS User ID: $freedns_id\n\
+FreeDNS password: $freedns_pass" 13 50
 ;;
-
 esac
  

--- a/menu_GC_Setup.sh
+++ b/menu_GC_Setup.sh
@@ -14,7 +14,8 @@ Press Enter to execute the highlighted option.\n" 17 50 7\
  "3" "Update platform"\
  "4" "Bootstrap the stable release"\
  "5" "Bootstrap the dev. release (advanced)"\
- "6" "Return"\
+ "6" "Enter FreeDNS ID and password"\
+ "7" "Return"\
  3>&1 1>&2 2>&3)
 
 case $Choice in
@@ -37,6 +38,7 @@ sudo cp -f update_scripts.sh /xDrip/scripts/. # Update the "update scripts" scri
 clear
 sudo /xDrip/scripts/update_scripts.sh
 sudo /xDrip/scripts/update_packages.sh
+sudo /xDrip/scripts/StartUpSetup.sh
 clear
 dialog --colors --msgbox "        \Zr Developed by the xDrip team \Zn\n\n\
 Close this terminal to complete updates." 7 50
@@ -51,6 +53,10 @@ curl https://raw.githubusercontent.com/jamorham/nightscout-vps/vps-dev/bootstrap
 ;;
 
 6)
+sudo /xDrip/scripts/update_FreeDNSCredentials.sh
+;;
+
+7)
 ;;
 
 esac

--- a/update_FreeDNSCredentials.sh
+++ b/update_FreeDNSCredentials.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+echo
+echo "Record FreeDNS user ID and password in /xDrip/FreeDNS_ID_Pass - Navid200"
+echo
+
+# If the FreeDNS password has been changed since installation, this script can be used to update it in our setup for auto-login.
+# If this system was created before we added auto-login, this script can be used to add user ID and password to our setup for auto login.
+
+freedns=$(wget --spider -S "https://freedns.afraid.org/" 2>&1 | awk '/HTTP\// {print $2}') # This will be 200 if FreeDNS is up.
+
+if [ $freedns -eq 200 ]  # Run the following only if FreeDNS is up.
+then
+  got_them=0
+  while [ $got_them -lt 1 ]
+  do
+  go_back=0
+  exec 3>&1
+  Values=$(dialog --colors --ok-label "Submit" --form "       \Zr Developed by the xDrip team \Zn\n\n\n\
+This utility lets you update your FreeDNS user ID and password in Google Cloud Nightscout.\n\
+It cannot update your user ID or password on the FreeDNS site.  To do that, you will need to use a browser and log into FreeDNS. Then, use this utility to update Google Cloud Nightscout accordingly.\n\n\
+Enter your ID and password to proceed.  Or press escape to cancel." 22 50 0 "User ID:" 1 1 "$user" 1 14 25 0 "Password:" 2 1 "$pass" 2 14 25 0 2>&1 1>&3)
+  response=$?
+  if [ $response = 255 ] || [ $response = 1 ] # cancled or escaped
+  then
+    clear
+    exit 5
+  fi
+  exec 3>&-
+  user=$(echo "$Values" | sed -n 1p)
+  pass=$(echo "$Values" | sed -n 2p)
+  arg1="https://freedns.afraid.org/api/?action=getdyndns&v=2&sha="
+  arg2=$(echo -n "$user|$pass" | sha1sum | awk '{print $1;}')
+  arg="$arg1$arg2"
+  wget -O /tmp/hosts "$arg"
+  if [ ! "`grep 'Could not authenticate' /tmp/hosts`" = "" ] # Failed to log in
+  then
+    dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nFailed to authenticate.  Please try again."  7 50
+    go_back=1
+  fi
+  if [ $go_back -lt 1 ] # Got them
+  then
+    got_them=1
+    cat > /xDrip/FreeDNS_ID_Pass << EOF
+#!/bin/sh
+# This file is generated automatically.  It will be deleted and recreated.
+# Please do not add anything to this file.
+export User_ID=$user
+export Password=$pass
+EOF
+
+  fi
+  done
+else # If FreeDNS is down
+  dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
+It seems the FreeDNS site is down.  Please try again when FreeDNS is back up." 9 50
+  cat > /tmp/FreeDNS_Failed << EOF
+The FreeDNS site is down.
+EOF
+
+fi


### PR DESCRIPTION
This PR has been tested using this branch: https://github.com/Navid200/cgm-remote-monitor/tree/FreeDNS_AutoLogin_PR_verify
If you want to test, this is the bootstrap: 

```
curl https://raw.githubusercontent.com/Navid200/cgm-remote-monitor/FreeDNS_AutoLogin_PR_verify/bootstrap.sh | bash
```

The following image shows what the new status page looks like.  Except that the red path to the test repository will be replaced with a path to the development branch of the main repository.
![Screenshot 2023-07-14 125049](https://github.com/jamorham/nightscout-vps/assets/51497406/f148e7bc-c4eb-47e8-8b56-6b73fc45e919)

Tapping on Credentials, will bring up this page:
![Screenshot 2023-07-14 132142](https://github.com/jamorham/nightscout-vps/assets/51497406/16822a09-4454-4df1-a814-f03f4d0785b9)

The following shows the new item on the Google Setup submenu.
![Screenshot 2023-07-14 125227](https://github.com/jamorham/nightscout-vps/assets/51497406/5f049d42-e869-4959-b1a0-f4f13853b1db)

This is the menu you will see if you choose to update the credentials in Google Cloud Nightscout.
![Screenshot 2023-07-16 124513](https://github.com/jamorham/nightscout-vps/assets/51497406/be0d4d8a-2707-4667-892f-81b79e87091d)

This is what the status page will look like, after a restart, if they change their FreeDNS password without updating it in our setup or if autologin fails to authenticate. This will not happen if the FreeDNS site is down.
![Screenshot 2023-07-16 124639](https://github.com/jamorham/nightscout-vps/assets/51497406/407ade82-0c22-4703-aa37-07686738eca0)
It's not in bright red because the system remains operational. It's just that auto-login will fail. I didn't consider this a disaster.

This is the log file showing the different possible logs.
![Screenshot 2023-07-16 125227](https://github.com/jamorham/nightscout-vps/assets/51497406/1a3eeb15-df30-4009-8573-86cec9ee3601)
  
This logs in at every restart. So, if someone is troubleshooting their variables in order to enable some app and they keep tweaking the variables, at every restart, there will be a login.
I can add a timer to only login if it has been more than 10 days. But, that will complicate the code.

---  
  
**What this does not do**
Imagine if you create a second FreeDNS account. Then, accidentally or by mistake, use the new utility to enter the user ID and password into Google Cloud Nightscout and enter the ID and password from your new account while Google Cloud Nightscout hostname is associated with your original FreeDNS account.

This is not marked as a failure on the status page.
The setup succeeds to login at every restart. But, it logs into your new account.
In 5.5 months, you will receive a reminder that your account is about to go dormant.

We can add more complexity to cover this as well. But, I plan to do this later because this is a very special case that not everyone will face.

The auto-login logs can be viewed manually. No item has been added to the menu to bring them up.
In 5.5 months, after testing, if this proves to be a success as far as being accepted as login, we can add that