### PR TITLE
Possibility to utilize own DNS instead of FreeDNS

### DIFF
--- a/ConfigServer/run_server_linux.sh
+++ b/ConfigServer/run_server_linux.sh
@@ -29,8 +29,8 @@ export APP_JSON_FILE=$SCRIPT_DIR/app.json
 sudo apt-get -y install python3-pip >> /tmp/variables_log 2>&1
 pip install Django django-extensions Werkzeug qrcode >> /tmp/variables_log 2>&1
 
-if test -f "/etc/free-dns.sh"; then
-. /etc/free-dns.sh
+if test -f "/etc/dns-config.sh"; then
+. /etc/dns-config.sh
 else
 export HOSTNAME=$(ls /etc/letsencrypt/live | grep -v README)
 fi

--- a/ConfigureDNS.sh
+++ b/ConfigureDNS.sh
@@ -16,7 +16,7 @@ do
     clear
     exec 3>&1
     Values=$(dialog --colors --ok-label "Submit" --form "       \Zr Developed by the xDrip team \Zn\n\n\n\
-Enter your hostname (e.g., nightscout.example.com - needs to be a subdomain!) and IP address (e.g., 34.111.222.12)." 12 50 0 "User ID:" 1 1 "$hostname" 1 14 25 0 "Password:" 2 1 "$ipaddress" 2 14 25 0 2>&1 1>&3)
+Enter your hostname and IP address." 12 60 0 "Hostname:" 1 1 "$hostname" 1 14 35 0 "IP address:" 2 1 "$ipaddress" 2 14 35 0 2>&1 1>&3)
     response=$?
     if [ $response = 255 ] || [ $response = 1 ] # canceled or escaped
     then

--- a/ConfigureDNS.sh
+++ b/ConfigureDNS.sh
@@ -53,74 +53,11 @@ done
 clear
 
 #create a file to store the data for the startup script.
-cat> /etc/free-dns.sh<<EOF
+cat> /etc/dns-config.sh<<EOF
 #!/bin/sh
 export HOSTNAME=$hostname
 export DIRECTURL=$ipaddress
 EOF
 
-# Start the first update immediately
-wget -O - --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 $ipaddress
-
-#Add the command to renew the script to the startup url
-if ! grep -q "DIRECTURL" /etc/rc.local; then
-    echo . /etc/free-dns.sh >>  /etc/rc.local
-    echo wget -O /tmp/freedns.txt --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 \$DIRECTURL >>  /etc/rc.local
-    echo exit 0 \# This should be the last line to ensure the startup will complete. >> /etc/rc.local
-fi
-
-dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
-Press enter to proceed.  Please be patient as it may take up to 10 minutes to complete." 8 50
-clear
-# wait for the ip to be updated. This might take up to 10 minutes.
-cnt=0
-while : ; do
-    sleep 30
-    registered=$(nslookup $hostname|tail -n2|grep A|sed s/[^0-9.]//g)
-    current=$(wget -q -O - http://checkip.dyndns.org|sed s/[^0-9.]//g)
-    echo $current $registered
-    [[ "$registered" != "$current" ]] || break
-    cnt=$((cnt+1))
-    echo $cnt
-    if (( cnt%6 == 0 )); then
-        echo "ccc" $cnt
-        wget -O - --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 $directurl
-    fi
-    sudo systemd-resolve --flush-caches
-    ping -c 1 $hostname
-    sudo systemd-resolve -4 $hostname
-    if [ $cnt -gt 20 ]
-    then
-        clear
-        dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
-Please close this window.  Open a new SSH terminal.  Run DNS Setup again to complete DNS setup." 9 50
-        exit
-    fi
-done
-
-#Fix the certificate using the new host name.
-
-
-for i in {1..4}
-do
-    for j in {1..1000}
-    do
-        read -t 0.001 dummy
-    done
-
-    sudo certbot --nginx -d "$hostname" --redirect --agree-tos --no-eff-email
-
-    if [ ! -s /etc/letsencrypt/live/"$hostname"/cert.pem ] || [ ! -s /etc/letsencrypt/live/"$hostname"/privkey.pem ]
-    then
-         echo DNS failed sleeping 
-         sleep 60
-    else
-        # worked, geting out of the loop.
-        exit 1
-    fi
-done
-cat > /tmp/FreeDNS_Failed << EOF
-Internal error.  Must run DNS setup again.
-EOF
-
-dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nInternal error.  Press enter to exit.  Then, run \"Install Nightscout phase 2\" again." 8 50
+# run the script right away to publish the variables
+. /etc/dns-config.sh

--- a/ConfigureDNS.sh
+++ b/ConfigureDNS.sh
@@ -52,6 +52,9 @@ Please try again." 16 50
 done
 clear
 
+export HOSTNAME=$hostname
+export DIRECTURL=$ipaddress
+
 #create a file to store the data for the startup script.
 cat> /etc/dns-config.sh<<EOF
 #!/bin/sh
@@ -59,5 +62,3 @@ export HOSTNAME=$hostname
 export DIRECTURL=$ipaddress
 EOF
 
-# run the script right away to publish the variables
-. /etc/dns-config.sh

--- a/ConfigureDNS.sh
+++ b/ConfigureDNS.sh
@@ -52,9 +52,6 @@ Please try again." 16 50
 done
 clear
 
-export HOSTNAME=$hostname
-export DIRECTURL=$ipaddress
-
 #create a file to store the data for the startup script.
 cat> /etc/dns-config.sh<<EOF
 #!/bin/sh

--- a/ConfigureDNS.sh
+++ b/ConfigureDNS.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+
+if [ "`id -u`" != "0" ]
+then
+    echo "Script needs root - use sudo bash ConfigureDNS.sh"
+    echo "Cannot continue."
+    exit 5
+fi
+
+sudo apt-get install bind9-dnsutils -y
+
+got_them=0
+while [ $got_them -lt 1 ]
+do
+    go_back=0
+    clear
+    exec 3>&1
+    Values=$(dialog --colors --ok-label "Submit" --form "       \Zr Developed by the xDrip team \Zn\n\n\n\
+Enter your hostname (e.g., nightscout.example.com - needs to be a subdomain!) and IP address (e.g., 34.111.222.12)." 12 50 0 "User ID:" 1 1 "$hostname" 1 14 25 0 "Password:" 2 1 "$ipaddress" 2 14 25 0 2>&1 1>&3)
+    response=$?
+    if [ $response = 255 ] || [ $response = 1 ] # canceled or escaped
+    then
+        clear
+        exit 5
+    fi
+
+    exec 3>&-
+    hostname=$(echo "$Values" | sed -n 1p)
+    ipaddress=$(echo "$Values" | sed -n 2p)
+
+    if [ "$hostname" = "" ] || [ "$ipaddress" = "" ] #  At least one parameter is blank. 
+    then
+        go_back=1
+        clear
+        dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
+You need to enter both hostname and IP address.  Try again."  8 50
+    fi
+    clear
+
+    if [ $go_back -lt 1 ]
+    then
+        if [[ "$ipaddress" =~ ^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$ ]]
+        then
+            dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
+Your IP address does not have the right format, it should look like, e.g., 34.111.222.12\n\n\
+Please try again." 16 50
+            go_back=1
+        else
+            got_them=1 # We have the hostname and IP address
+        fi
+    fi
+done
+clear
+
+#create a file to store the data for the startup script.
+cat> /etc/free-dns.sh<<EOF
+#!/bin/sh
+export HOSTNAME=$hostname
+export DIRECTURL=$ipaddress
+EOF
+
+# Start the first update immediately
+wget -O - --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 $ipaddress
+
+#Add the command to renew the script to the startup url
+if ! grep -q "DIRECTURL" /etc/rc.local; then
+    echo . /etc/free-dns.sh >>  /etc/rc.local
+    echo wget -O /tmp/freedns.txt --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 \$DIRECTURL >>  /etc/rc.local
+    echo exit 0 \# This should be the last line to ensure the startup will complete. >> /etc/rc.local
+fi
+
+dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
+Press enter to proceed.  Please be patient as it may take up to 10 minutes to complete." 8 50
+clear
+# wait for the ip to be updated. This might take up to 10 minutes.
+cnt=0
+while : ; do
+    sleep 30
+    registered=$(nslookup $hostname|tail -n2|grep A|sed s/[^0-9.]//g)
+    current=$(wget -q -O - http://checkip.dyndns.org|sed s/[^0-9.]//g)
+    echo $current $registered
+    [[ "$registered" != "$current" ]] || break
+    cnt=$((cnt+1))
+    echo $cnt
+    if (( cnt%6 == 0 )); then
+        echo "ccc" $cnt
+        wget -O - --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 $directurl
+    fi
+    sudo systemd-resolve --flush-caches
+    ping -c 1 $hostname
+    sudo systemd-resolve -4 $hostname
+    if [ $cnt -gt 20 ]
+    then
+        clear
+        dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
+Please close this window.  Open a new SSH terminal.  Run DNS Setup again to complete DNS setup." 9 50
+        exit
+    fi
+done
+
+#Fix the certificate using the new host name.
+
+
+for i in {1..4}
+do
+    for j in {1..1000}
+    do
+        read -t 0.001 dummy
+    done
+
+    sudo certbot --nginx -d "$hostname" --redirect --agree-tos --no-eff-email
+
+    if [ ! -s /etc/letsencrypt/live/"$hostname"/cert.pem ] || [ ! -s /etc/letsencrypt/live/"$hostname"/privkey.pem ]
+    then
+         echo DNS failed sleeping 
+         sleep 60
+    else
+        # worked, geting out of the loop.
+        exit 1
+    fi
+done
+cat > /tmp/FreeDNS_Failed << EOF
+Internal error.  Must run DNS setup again.
+EOF
+
+dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nInternal error.  Press enter to exit.  Then, run \"Install Nightscout phase 2\" again." 8 50

--- a/ConfigureFreedns.sh
+++ b/ConfigureFreedns.sh
@@ -148,3 +148,11 @@ cat> /etc/dns-config.sh<<EOF
 export HOSTNAME=$hostname
 export DIRECTURL=$directurl
 EOF
+
+else  # If FreeDNS is down
+dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
+It seems the DNS site is down.  Please try again when DNS is back up." 9 50
+cat > /tmp/DNS-config_Failed << EOF
+The FreeDNS site is down.
+EOF
+fi

--- a/ConfigureFreedns.sh
+++ b/ConfigureFreedns.sh
@@ -142,9 +142,6 @@ read -a split <<< $FLine
 hostname=${split[0],,}
 directurl=${split[2]}
 
-export HOSTNAME=$hostname
-export DIRECTURL=$directurl
-
 #create a file to store the data for the startup script.
 cat> /etc/dns-config.sh<<EOF
 #!/bin/sh

--- a/ConfigureFreedns.sh
+++ b/ConfigureFreedns.sh
@@ -142,12 +142,12 @@ read -a split <<< $FLine
 hostname=${split[0],,}
 directurl=${split[2]}
 
+export HOSTNAME=$hostname
+export DIRECTURL=$directurl
+
 #create a file to store the data for the startup script.
 cat> /etc/dns-config.sh<<EOF
 #!/bin/sh
 export HOSTNAME=$hostname
 export DIRECTURL=$directurl
 EOF
-
-# run the script right away to publish the variables
-. /etc/dns-config.sh

--- a/DNS-config.sh
+++ b/DNS-config.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+if [ "`id -u`" != "0" ]
+then
+echo "Script needs root - use sudo bash DNS-config.sh"
+echo "Cannot continue."
+exit 5
+fi
+
+# Start the first update immediately
+wget -O - --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 $DIRECTURL
+
+#Add the command to renew the script to the startup url
+if ! grep -q "DIRECTURL" /etc/rc.local; then
+    echo . /etc/dns-config.sh >>  /etc/rc.local
+    echo wget -O /tmp/dns-config.txt --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 \$DIRECTURL >>  /etc/rc.local
+    echo exit 0 \# This should be the last line to ensure the startup will complete. >> /etc/rc.local
+fi
+
+dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
+Press enter to proceed.  Please be patient as it may take up to 10 minutes to complete." 8 50
+clear
+# wait for the ip to be updated. This might take up to 10 minutes.
+cnt=0
+while : ; do
+    sleep 30
+    registered=$(nslookup $HOSTNAME|tail -n2|grep A|sed s/[^0-9.]//g)
+    current=$(wget -q -O - http://checkip.dyndns.org|sed s/[^0-9.]//g)
+    echo $current $registered
+    [[ "$registered" != "$current" ]] || break
+    cnt=$((cnt+1))
+    echo $cnt
+    if (( cnt%6 == 0 )); then
+         echo "ccc" $cnt
+        wget -O - --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 $DIRECTURL
+    fi
+    sudo systemd-resolve --flush-caches
+    ping -c 1 $HOSTNAME
+    sudo systemd-resolve -4 $HOSTNAME
+    if [ $cnt -gt 20 ]
+    then
+      clear
+      dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
+Please close this window.  Open a new SSH terminal.  Run DNS Setup again to complete DNS setup." 9 50
+      exit
+    fi
+done
+
+#Fix the certificate using the new host name.
+
+
+for i in {1..4}
+do
+    for j in {1..1000}
+    do
+    read -t 0.001 dummy
+    done
+
+    sudo certbot --nginx -d "$HOSTNAME" --redirect --agree-tos --no-eff-email
+
+    if [ ! -s /etc/letsencrypt/live/"$HOSTNAME"/cert.pem ] || [ ! -s /etc/letsencrypt/live/"$HOSTNAME"/privkey.pem ]
+    then
+
+         echo freedns failed sleeping 
+         sleep 60
+    else
+        # worked, geting out of the loop.
+        exit 1
+    fi
+done
+cat > /tmp/DNS-config_Failed << EOF
+Internal error.  Must run DNS setup again.
+EOF
+
+dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nInternal error.  Press enter to exit.  Then, run \"Install Nightscout phase 2\" again." 8 50
+
+else  # If DNS is down
+dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
+It seems the DNS site is down.  Please try again when DNS is back up." 9 50
+cat > /tmp/DNS-config_Failed << EOF
+The DNS site is down.
+EOF
+fi

--- a/DNS-config.sh
+++ b/DNS-config.sh
@@ -7,6 +7,10 @@ echo "Cannot continue."
 exit 5
 fi
 
+# Get HOSTNAME and DIRECTURL
+. /etc/dns-config.sh
+echo HOSTNAME=$HOSTNAME - DIRECTURL=$DIRECTURL
+
 # Start the first update immediately
 wget -O - --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 $DIRECTURL
 

--- a/DNS-config.sh
+++ b/DNS-config.sh
@@ -77,11 +77,3 @@ Internal error.  Must run DNS setup again.
 EOF
 
 dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nInternal error.  Press enter to exit.  Then, run \"Install Nightscout phase 2\" again." 8 50
-
-else  # If DNS is down
-dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
-It seems the DNS site is down.  Please try again when DNS is back up." 9 50
-cat > /tmp/DNS-config_Failed << EOF
-The DNS site is down.
-EOF
-fi

--- a/NS_Install2.sh
+++ b/NS_Install2.sh
@@ -177,7 +177,7 @@ sudo systemctl start rc-local.service
 /xDrip/scripts/menu_DNS.sh
 
 # Configure DNS
-/xDrip/scripts/ConfigureDNS.sh
+/xDrip/scripts/DNS-config.sh
 if [ ! -s /tmp/DNS-config_Failed ]
 then
 clear

--- a/NS_Install2.sh
+++ b/NS_Install2.sh
@@ -173,7 +173,7 @@ sudo systemctl enable rc-local
 
 sudo systemctl start rc-local.service
  
-sudo /xDrip/scripts/ConfigureFreedns.sh
+/xDrip/scripts/menu_DNS.sh
 if [ ! -s /tmp/FreeDNS_Failed ]
 then
 clear

--- a/NS_Install2.sh
+++ b/NS_Install2.sh
@@ -173,8 +173,12 @@ sudo systemctl enable rc-local
 
 sudo systemctl start rc-local.service
  
+# Get DNS parameters (hostname, IP address)
 /xDrip/scripts/menu_DNS.sh
-if [ ! -s /tmp/FreeDNS_Failed ]
+
+# Configure DNS
+/xDrip/scripts/ConfigureDNS.sh
+if [ ! -s /tmp/DNS-config_Failed ]
 then
 clear
 

--- a/Status.sh
+++ b/Status.sh
@@ -86,7 +86,7 @@ branch="\Zb\Z1$(< /srv/brnch)\Zn" # Set the color to red if the branch name is n
 fi
 
 HOSTNAME=""
-. /etc/free-dns.sh
+. /etc/dns-config.sh
 if [ "$HOSTNAME" = "" ]
 then
 FD="No hostname"
@@ -154,7 +154,7 @@ $Missing $Phase1 $rclocal_1 \n\n\
 Swap: $swap \n\
 Mongo: $mongo \n\
 NS proc: $ns \n\
-FreeDNS name and IP: $FD \n\
+DNS name and IP: $FD \n\
 Certificate: $cert \
  " 29 50 2\
  "1" "Return"\
@@ -170,7 +170,7 @@ exit
 2)
 dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
                \Zb\Z1Keep private.\Zn\n\
-FreeDNS hostname:  $HOSTNAME\n\
+DNS hostname:  $HOSTNAME\n\
 API_SECRET: $apisec" 9 50
 ;;
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -59,7 +59,7 @@ sudo mkdir scripts
 
 cd /srv
 sudo rm -rf *
-sudo git clone https://github.com/jamorham/nightscout-vps.git  # ✅✅✅✅✅ Main - Uncomment before PR.
+sudo git clone https://github.com/ulricusr/nightscout-vps.git  # ✅✅✅✅✅ Main - Uncomment before PR.
 #sudo git clone https://github.com/Navid200/cgm-remote-monitor.git  # ⛔⛔⛔⛔⛔ For test - Comment out before PR.
 
 ls > /tmp/repo

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -59,7 +59,7 @@ sudo mkdir scripts
 
 cd /srv
 sudo rm -rf *
-sudo git clone https://github.com/ulricusr/nightscout-vps.git  # ✅✅✅✅✅ Main - Uncomment before PR.
+sudo git clone https://github.com/jamorham/nightscout-vps.git  # ✅✅✅✅✅ Main - Uncomment before PR.
 #sudo git clone https://github.com/Navid200/cgm-remote-monitor.git  # ⛔⛔⛔⛔⛔ For test - Comment out before PR.
 
 ls > /tmp/repo

--- a/menu_DNS.sh
+++ b/menu_DNS.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+echo
+echo "Bringing up the Nightscout setup menu" - UlricusR
+echo
+
+clear
+Choice=$(dialog --colors --nocancel --nook --menu "\
+        \Zr Developed by the xDrip team \Zn\
+  \n\n
+Use the arrow keys to move the cursor.\n\
+Press Enter to execute the highlighted option.\n" 14 50 4\
+ "1" "Use FreeDNS"\
+ "2" "Directly enter own hostname and IP address"\
+ "3" "Return"\
+ 3>&1 1>&2 2>&3)
+
+case $Choice in
+
+
+1)
+sudo /xDrip/scripts/ConfigureFreedns.sh
+;;
+
+2)
+sudo /xDrip/scripts/ConfigureDNS.sh
+;;
+
+3)
+;;
+
+esac
+  

--- a/menu_DNS.sh
+++ b/menu_DNS.sh
@@ -9,7 +9,7 @@ Choice=$(dialog --colors --nocancel --nook --menu "\
         \Zr Developed by the xDrip team \Zn\
   \n\n
 Use the arrow keys to move the cursor.\n\
-Press Enter to execute the highlighted option.\n" 13 60 3\
+Press Enter to execute the highlighted option.\n" 13 50 3\
  "1" "Use FreeDNS"\
  "2" "Directly enter own hostname and IP address"\
  "3" "Return"\

--- a/menu_DNS.sh
+++ b/menu_DNS.sh
@@ -9,7 +9,7 @@ Choice=$(dialog --colors --nocancel --nook --menu "\
         \Zr Developed by the xDrip team \Zn\
   \n\n
 Use the arrow keys to move the cursor.\n\
-Press Enter to execute the highlighted option.\n" 14 50 4\
+Press Enter to execute the highlighted option.\n" 13 60 3\
  "1" "Use FreeDNS"\
  "2" "Directly enter own hostname and IP address"\
  "3" "Return"\

--- a/qrCodeMaster.sh
+++ b/qrCodeMaster.sh
@@ -5,7 +5,7 @@ echo "Show the base URL required to become master" - Navid200
 echo
 
 HOSTNAME=""
-. /etc/free-dns.sh
+. /etc/dns-config.sh
 
 . /etc/nsconfig
 apisec=$API_SECRET


### PR DESCRIPTION
I added a feature to configure an own DNS instead of using FreeDNS.

Changes made:
1.) Split the original ConfigureFreedns.sh into two parts - part 1 (same file name) to retrieve hostname and IP from FreeDNS, part 2 (new file: DNS-config.sh) to configure the DNS (from amending rc.local to getting the certificate).
2.) Added a new script ConfigureDNS.sh, where a user can directly enter hostname and IP address into a dialog.
3.) Introduced a new menu_DNS.sh, where the user can select between FreeDNS and own DNS configuration. If the user selects FreeDNS, the ConfigureFreedns script modified in step 1 will be called; if the user selects own DNS configuration, the new ConfigureDNS.sh script will be called. Both scripts finally write HOSTNAME and DIRECTURL into the (renamed) /etc/dns-config.sh script.
4.) Modified NS_Install2.sh to first call the new menu_DNS script from step 3 instead of directly the ConfigureFreedns script, and then (in both cases) call the DNS-config script from step 1.

Tests performed:
Ran both pathes (FreeDNS and own DNS) on new Google VMs with expected results.

Feel free to reach out and happy if the proposed change would make it to the main vps version.

If so, I am volunteering to update the documentation, if you tell me where I can find the source files.