### PR TITLE
Update ConfigureFreedns.sh

### DIFF
--- a/ConfigureFreedns.sh
+++ b/ConfigureFreedns.sh
@@ -118,14 +118,6 @@ then
         else
           FLine=$(</tmp/FullLine)
           got_them=1 # We have the hostname and direct URL
-          rm -rf /xDrip/FreeDNS_ID_Pass
-cat > /xDrip/FreeDNS_ID_Pass << EOF
-#!/bin/sh
-# This file is generated automatically.  It will be deleted and recreated.
-# Please do not add anything to this file.
-export User_ID=$user
-export Password=$pass
-EOF
           
         fi # fi 1
 
@@ -156,6 +148,16 @@ cat> /etc/free-dns.sh<<EOF
 #!/bin/sh
 export HOSTNAME=$hostname
 export DIRECTURL=$directurl
+EOF
+
+# Create a file to store the FreeDNS user ID and password.
+rm -rf /xDrip/FreeDNS_ID_Pass
+cat > /xDrip/FreeDNS_ID_Pass << EOF
+#!/bin/sh
+# This file is generated automatically.  It will be deleted and recreated.
+# Please do not add anything to this file.
+export User_ID=$user
+export Password=$pass
 EOF
 
 # Start the first update immediately

--- a/Status.sh
+++ b/Status.sh
@@ -163,7 +163,7 @@ Disk size: $disksz        $DiskUsedPercent used \n\
 Ubuntu: $ubuntu \n\
 HTTP & HTTPS:  $http \n\
 ------------------------------------------ \n\
-Google Cloud Nightscout  2023.07.17\n\
+Google Cloud Nightscout  2023.07.21\n\
 $Missing $Phase1 $rclocal_1 $freedns_id_pass \n\n\
 /$uname/$repo/$branch\n\
 Swap: $swap \n\


### PR DESCRIPTION
 Corrected the condition for creating the file to store the FreeDNS user ID and password.

The file was only created if there were multiple subdomains.  But, if there was only one subdomain, the file creating would be skipped.

This PR corrects that by placing the file creation where it should have been in the first place.