### PR TITLE
FreeDNS id pass issue marker missing after update

### DIFF
--- a/Status.sh
+++ b/Status.sh
@@ -147,7 +147,7 @@ then
   freedns_pass=$Password
 fi
 freedns_id_pass=""
-if [ -s /xDrip/FreeDNS_Fail ] || [ ! -s /xDrip/FreeDNS_IDPass ]
+if [ -s /xDrip/FreeDNS_Fail ] || [ ! -s /xDrip/FreeDNS_ID_Pass ]
 then
   freedns_id_pass="\Zb\Z5FreeDNS ID and pass\Zn"
 fi

--- a/Status.sh
+++ b/Status.sh
@@ -147,7 +147,7 @@ then
   freedns_pass=$Password
 fi
 freedns_id_pass=""
-if [ -s /xDrip/FreeDNS_Fail ]
+if [ -s /xDrip/FreeDNS_Fail ] || [ ! -s /xDrip/FreeDNS_IDPass ]
 then
   freedns_id_pass="\Zb\Z5FreeDNS ID and pass\Zn"
 fi


### PR DESCRIPTION
I updated my main machine.
I expected to see the marker on the status page.  But, there wasn't one.
The reason is that after update, you will not see the marker until a reboot.  An automatic reboot takes place about once a week.  But, this is a problem because after someone updates, they may never log back in for a very long time.

This PR changes that.  As soon as an update, even if you don't restart, the marker will be shown on the status page because the FreeDNS_ID_Pass file will be missing.
So, the user will see something is wrong and they can fix it by running the new utility that asks for the user ID and password and create the file.