### PR TITLE
API_SECRET exclusions updated

### DIFF
--- a/NS_Install2.sh
+++ b/NS_Install2.sh
@@ -99,9 +99,9 @@ go_back=0
 clear
 exec 3>&1
 Value=$(dialog --colors --ok-label "Submit" --form "       \Zr Developed by the xDrip team \Zn\n\n\n\
-Your current API_SECRET is $cs\n\n\
-You can press escape to keep it unchanged.  Or, enter a new one with at least 12 characters excluding the following.\n\n\
-$  \"  '  \\ \n " 19 50 0 "API_SECRET:" 1 1 "$secr" 1 14 25 0 2>&1 1>&3)
+API_SECRET:   $cs\n\n\
+Press escape to keep it, or enter a new API_SECRET with at least 12 characters excluding the following.\n\
+  $   \"   '   \\   SPACE   @   / " 16 50 0 "API_SECRET:" 1 1 "$secr" 1 14 25 0 2>&1 1>&3)
 response=$?
 if [ $response = 255 ] || [ $response = 1 ] # cancled or escaped
 then
@@ -122,12 +122,12 @@ clear
 
 if [ $go_back -lt 1 ]
 then
-  if [[ $ns == *[\$]* ]] || [[ $ns == *[\"]* ]] || [[ $ns == *[\']* ]] || [[ $ns == *[\\]* ]] # Reject if submission contains unacceptable characters.
+  if [[ $ns == *[\$]* ]] || [[ $ns == *[\"]* ]] || [[ $ns == *[\']* ]] || [[ $ns == *[\\]* ]] || [[ $ns == *[\ ]* ]] || [[ $ns == *[@]* ]] || [[ $ns == *[\/]* ]] # Reject if submission contains unacceptable characters.
   then
     go_back=1
     clear
     dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
-API_SECRET should not include $, \\, ' or \".  Please try again."  8 50
+API_SECRET should not include the following characters. Please try again.\n $  \"  \\  '  SPACE  @  /"  9 50
   else
     got_it=1
   fi

--- a/Status.sh
+++ b/Status.sh
@@ -163,7 +163,7 @@ Disk size: $disksz        $DiskUsedPercent used \n\
 Ubuntu: $ubuntu \n\
 HTTP & HTTPS:  $http \n\
 ------------------------------------------ \n\
-Google Cloud Nightscout  2023.07.22\n\
+Google Cloud Nightscout  2023.08.31\n\
 $Missing $Phase1 $rclocal_1 $freedns_id_pass \n\n\
 /$uname/$repo/$branch\n\
 Swap: $swap \n\


### PR DESCRIPTION
1- The date on the status page updated.  
  
2- API_SECRET exclusions extended to the following.  
$ &nbsp;  " &nbsp;  ' &nbsp;  \ &nbsp;  / &nbsp;  @ &nbsp;  SPACE 
These are only shown, and verified, during installation.  User can still edit their variables and add any of them back.  There is no flag on the status page for any of these.  We can add such in the future.