### PR TITLE
API_SECRET unacceptable characters

### DIFF
--- a/NS_Install2.sh
+++ b/NS_Install2.sh
@@ -99,9 +99,9 @@ go_back=0
 clear
 exec 3>&1
 Value=$(dialog --colors --ok-label "Submit" --form "       \Zr Developed by the xDrip team \Zn\n\n\n\
-Your current API_SECRET is $cs\n\n\
-You can press escape to keep it unchanged.  Or, enter a new one with at least 12 characters excluding the following.\n\n\
-$  \"  '  \\ \n " 19 50 0 "API_SECRET:" 1 1 "$secr" 1 14 25 0 2>&1 1>&3)
+API_SECRET:   $cs\n\n\
+Press escape to keep it, or enter a new API_SECRET with at least 12 characters excluding the following.\n\
+  $   \"   '   \\   SPACE   @   / " 16 50 0 "API_SECRET:" 1 1 "$secr" 1 14 25 0 2>&1 1>&3)
 response=$?
 if [ $response = 255 ] || [ $response = 1 ] # cancled or escaped
 then
@@ -122,12 +122,12 @@ clear
 
 if [ $go_back -lt 1 ]
 then
-  if [[ $ns == *[\$]* ]] || [[ $ns == *[\"]* ]] || [[ $ns == *[\']* ]] || [[ $ns == *[\\]* ]] # Reject if submission contains unacceptable characters.
+  if [[ $ns == *[\$]* ]] || [[ $ns == *[\"]* ]] || [[ $ns == *[\']* ]] || [[ $ns == *[\\]* ]] || [[ $ns == *[\ ]* ]] || [[ $ns == *[@]* ]] || [[ $ns == *[\/]* ]] # Reject if submission contains unacceptable characters.
   then
     go_back=1
     clear
     dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
-API_SECRET should not include $, \\, ' or \".  Please try again."  8 50
+API_SECRET should not include the following characters. Please try again.\n $  \"  \\  '  SPACE  @  /"  9 50
   else
     got_it=1
   fi

--- a/Status.sh
+++ b/Status.sh
@@ -101,9 +101,6 @@ FD="Match"
 fi
 fi
 
-. /etc/nsconfig
-apisec=$API_SECRET
-
 curl https://$HOSTNAME > /tmp/$HOSTNAME.txt
 curl_ret=$?
 if (( curl_ret != 0 )); then
@@ -152,6 +149,16 @@ then
   freedns_id_pass="\Zb\Z5FreeDNS ID and pass\Zn"
 fi
 
+# Mark existence of problem characters in API_SECRET
+apisec_literal=$(grep 'API_SECRET=' /etc/nsconfig | sed 's/^.*=//')
+apisec_literal="$apisec_literal"
+apisec_literal="${apisec_literal:1: -1}"
+apisec_problem=""
+if [[ "$apisec_literal" == *"@"* ]] || [[ "$apisec_literal" == *" "* ]] || [[ "$apisec_literal" == *"/"* ]] || [[ "$apisec_literal" == *"\\"* ]] || [[ "$apisec_literal" == *"'"* ]] || [[ "$apisec_literal" == *"\""* ]] || [[ "$apisec_literal" == *"$"* ]] || [[ ${#apisec_literal} -lt 12 ]]
+then
+  apisec_problem="*" # Visible, but not obtrusive
+fi
+
 clear
 Choice=$(dialog --colors --nocancel --nook --menu "\
         \Zr Developed by the xDrip team \Zn\n\n\
@@ -163,8 +170,8 @@ Disk size: $disksz        $DiskUsedPercent used \n\
 Ubuntu: $ubuntu \n\
 HTTP & HTTPS:  $http \n\
 ------------------------------------------ \n\
-Google Cloud Nightscout  2023.07.22\n\
-$Missing $Phase1 $rclocal_1 $freedns_id_pass \n\n\
+Google Cloud Nightscout  2023.09.02\n\
+$apisec_problem $Missing $Phase1 $rclocal_1 $freedns_id_pass\n\n\
 /$uname/$repo/$branch\n\
 Swap: $swap \n\
 Mongo: $mongo \n\
@@ -186,7 +193,7 @@ exit
 dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
               \Zb\Z1Keep private!\Zn\n\n\
 Hostname:  $HOSTNAME\n\
-API_SECRET: $apisec\n\n\
+API_SECRET: $apisec_literal\n\n\
 FreeDNS User ID: $freedns_id\n\
 FreeDNS password: $freedns_pass" 13 50
 ;;


### PR DESCRIPTION
This PR increases the number of characters that should be excluded from API_SECRET to 7.

During installation, the characters will not be allowed.

If the Nightscout variables are edited after installation and problem characters are added to API_SECRET, the status page will highlight this with a non-obtrusive marker as shown below.
Also, if the number of characters is reduced to less than 12, the marker will be shown on the status page.
![Screenshot 2023-09-01 091723](https://github.com/jamorham/nightscout-vps/assets/51497406/4296faf2-d957-44bd-ba51-ed8e466d106b)