### PR TITLE
API_SECRET verification

### DIFF
--- a/NS_Install2.sh
+++ b/NS_Install2.sh
@@ -99,9 +99,9 @@ go_back=0
 clear
 exec 3>&1
 Value=$(dialog --colors --ok-label "Submit" --form "       \Zr Developed by the xDrip team \Zn\n\n\n\
-Your current API_SECRET is $cs\n\n\
-You can press escape to keep it unchanged.  Or, enter a new one with at least 12 characters excluding the following.\n\n\
-$  \"  '  \\ \n " 19 50 0 "API_SECRET:" 1 1 "$secr" 1 14 25 0 2>&1 1>&3)
+API_SECRET:   $cs\n\n\
+Press escape to keep it, or enter a new API_SECRET with at least 12 characters excluding the following.\n\
+  $   \"   '   \\   SPACE   @   / " 16 50 0 "API_SECRET:" 1 1 "$secr" 1 14 25 0 2>&1 1>&3)
 response=$?
 if [ $response = 255 ] || [ $response = 1 ] # cancled or escaped
 then
@@ -122,12 +122,12 @@ clear
 
 if [ $go_back -lt 1 ]
 then
-  if [[ $ns == *[\$]* ]] || [[ $ns == *[\"]* ]] || [[ $ns == *[\']* ]] || [[ $ns == *[\\]* ]] # Reject if submission contains unacceptable characters.
+  if [[ $ns == *[\$]* ]] || [[ $ns == *[\"]* ]] || [[ $ns == *[\']* ]] || [[ $ns == *[\\]* ]] || [[ $ns == *[\ ]* ]] || [[ $ns == *[@]* ]] || [[ $ns == *[\/]* ]] # Reject if submission contains unacceptable characters.
   then
     go_back=1
     clear
     dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
-API_SECRET should not include $, \\, ' or \".  Please try again."  8 50
+API_SECRET should not include the following characters. Please try again.\n $  \"  \\  '  SPACE  @  /"  9 50
   else
     got_it=1
   fi


### PR DESCRIPTION
This PR increases the number of characters that should be excluded from API_SECRET to 7.  Those are:
@  &nbsp;  $ &nbsp;  / &nbsp;  \ &nbsp;  ' &nbsp;  " &nbsp;  SPACE

During installation, the characters will not be allowed.  
  
If the Nightscout variables are edited after installation and problem characters are added to API_SECRET, the status page will highlight this with a non-obtrusive marker as shown below.  
![Screenshot 2023-09-08 110248](https://github.com/jamorham/nightscout-vps/assets/51497406/88ec025f-4509-4083-9f6e-ff85124b3a49)
It's a single star character shown under the Google Cloud Nightsocut line.
The marker is intentionally chosen to not stand out.  There are cases a user may choose to use one of those characters.  If their uploader and Nightsocut work fine, we will not interfere.
Also, if the number of characters is reduced to less than 12, the same marker will be shown on the status page.

