### PR TITLE
Initial file to analyze the logs of nginx.

### DIFF
--- a/etc/analyze_nginx.py
+++ b/etc/analyze_nginx.py
@@ -1,0 +1,82 @@
+
+# This function is used to fix the splited readings.
+# For example something like: "+0000] "POST /api/v1/entries.json HTTP/1.1" 200 we combine the "POST /api/v1/entries.json HTTP/1.1" to one entry.
+def FixSplit(line):
+    ret = []
+    adding = False
+    tmp = ""
+    for word in line:
+        word = word.rstrip()
+        if word[0] == '"' and word[-1] == '"':
+            ret.append(word)
+            continue
+        if not adding:
+            if word[0] == '"':
+                adding = True
+                tmp = word
+            else:
+                ret.append(word)
+        else:
+            tmp = tmp + word
+            #print(word, word[-1])
+            if word[-1] == '"':
+                #print("end of wooors")
+                adding = False
+                ret.append(tmp)
+                tmp=""
+    return ret
+    
+
+def TrimByChar(str, char):
+    pos = str.find(char)
+    if pos == -1:
+        return str
+    return str[0:pos]
+       
+
+def CreateHist(lines):
+    i = 0
+    sum = 0
+    agent_hist = {}
+    request_hist = {}
+    for line in lines:
+        split = line.split()
+        #print(len(split))
+
+        split1 = FixSplit(split)
+        #print(i, split1)
+        #print(i, split1[7], split1[9])
+        egress = split1[7]
+        agent = split1[9]
+        request = split1[5]
+        request = TrimByChar(request, "?")
+
+       
+        request.find('?')
+        #print(request)
+        sum += int(egress)
+        i +=1
+        agent_hist[agent] = agent_hist.get(agent, 0) +  int(egress)
+        request_hist[request] = request_hist.get(request, 0) +  int(egress)
+
+    print("Total lines in file:", i, "Total egresses traffic", sum)
+
+
+    # Print the agent_hist based on agent
+    print("\nAgent historgram")
+    for value, key in sorted( ((v,k) for k,v in agent_hist.items()), reverse=True):
+        if value < 100000: continue
+        print(key, ' : ', value / 1000000)
+
+    
+    print("\nrequest historgram\n")
+    # Print the request_his based on agent
+    for value, key in sorted( ((v,k) for k,v in request_hist.items()), reverse=True):
+        if value < 100000: continue
+        print(key, ' : ', value / 1000000)
+
+
+with open("c:\\Users\\nirit\\Downloads\\access.log") as file:
+    lines = [line.rstrip('\n') for line in file]
+
+CreateHist(lines)


### PR DESCRIPTION
This can help in finding the reason why so much traffic is used.

Example of an output:

Total lines in file: 8430 Total egresses traffic 67010600

Agent historgram
"Mozilla/5.0(iPhone;CPUiPhoneOS17_0likeMacOSX)AppleWebKit/605.1.15(KHTML,likeGecko)" :  38.380733
"iAPS/26CFNetwork/1474Darwin/23.0.0"  :  10.894845 "Mozilla/5.0(Macintosh;IntelMacOSX10_15_7)AppleWebKit/605.1.15(KHTML,likeGecko)Version/16.6Safari/605.1.15" :  9.576064
"Loop%20Follow/8CFNetwork/1474Darwin/23.0.0"  :  5.95387 "python-requests/2.26.0"  :  0.409005
"-"  :  0.40868
"Mozilla/5.0(WindowsNT10.0;Win64;x64)AppleWebKit/537.36(KHTML,likeGecko)Chrome/114.0.0.0Safari/537.36" :  0.233803
"Expanse,aPaloAltoNetworkscompany,searchesacrosstheglobalIPv4spacemultipletimesperdaytoidentifycustomers&#39;presencesontheInternet.Ifyouwouldliketobeexcludedfromoursca ns,pleasesendIPaddresses/domainsto:scaninfo@paloaltonetworks.com"  : 0.214875
"ScriptableWidgetExtension/1CFNetwork/1474Darwin/23.0.0"  :  0.191176 "Mozilla/5.0(Macintosh;IntelMacOSX10_10_1)AppleWebKit/537.36(KHTML,likeGecko)Chrome/41.0.2227.1Safari/537.36" :  0.116393
"Mozilla/5.0(WindowsNT6.1)AppleWebKit/537.36(KHTML,likeGecko)Chrome/49.0.2623.112Safari/537.36" :  0.107068

request historgram

"GET/api/v1/devicestatus.json  :  31.063223
"GET/api/v1/treatments.json  :  11.793686
"POST/api/v1/treatments.jsonHTTP/1.1"  :  8.193446
"GET/api/v1/entries.json  :  8.082024
"GET/socket.io/  :  2.113974
"POST/api/v1/entries.jsonHTTP/1.1"  :  1.650847
"GET/api/v1/entries/sgv.json  :  1.031043
"GET/HTTP/1.1"  :  1.001189
"POST/api/v1/devicestatus.jsonHTTP/1.1"  :  0.423586
"GET/api/v2/properties  :  0.191176
"GET/api/v1/profiles  :  0.186342
"GET/HTTP/1.0"  :  0.1719
"GET/audio/alarm2.mp3HTTP/1.1"  :  0.141126