### PR TITLE
Ubuntu update 5p8 promote

### DIFF
--- a/Status.sh
+++ b/Status.sh
@@ -197,7 +197,7 @@ Disk size: $disksz        $DiskUsedPercent used \n\
 Ubuntu: $ubuntu \n\
 HTTP & HTTPS:  $http \n\
 ------------------------------------------ \n\
-Google Cloud Nightscout  2024.01.29\n\
+Google Cloud Nightscout  2024.02.24\n\
 $apisec_problem $Missing $Phase1 $rclocal_1 $freedns_id_pass \n\n\
 /$uname/$repo/$branch\n\
 Swap: $swap \n\

--- a/update_packages.sh
+++ b/update_packages.sh
@@ -12,7 +12,7 @@ sudo apt-get update
 
 #Ubuntu upgrade available
 NextUbuntu="$(apt-get -s upgrade | grep 'Inst base' | awk '{print $4}' | sed 's/(//')"
-if [ "$NextUbuntu" = "11ubuntu5.7" ] # Only upgrade if we have tested the next release
+if [ "$NextUbuntu" = "11ubuntu5.8" ] # Only upgrade if we have tested the next release
 then
   sudo apt-get -y upgrade
 fi


### PR DESCRIPTION
This PR will change the conditional to allow updating to the current latest Ubuntu on 20.04 (5.8).