### PR TITLE
Remove bootstrap menu items

### DIFF
--- a/Status.sh
+++ b/Status.sh
@@ -204,7 +204,7 @@ Disk size: $disksz        $DiskUsedPercent used \n\
 Ubuntu: $ubuntu \n\
 HTTP & HTTPS:  $http \n\
 ------------------------------------------ \n\
-Google Cloud Nightscout  2024.08.28\n\
+Google Cloud Nightscout  2024.12.19\n\
 $apisec_problem $Missing $Phase1 $rclocal_1 $freedns_id_pass \n\n\
 /$uname/$repo/$branch\n\
 Swap: $swap \n\

--- a/menu_GC_Setup.sh
+++ b/menu_GC_Setup.sh
@@ -12,8 +12,7 @@ Press Enter to execute the highlighted option.\n" 17 50 7\
  "1" "Install Nightscout phase 1 - 15 minutes"\
  "2" "Install Nightscout phase 2 - 5 minutes"\
  "3" "Update platform"\
- "4" "Enter FreeDNS ID and password"\
- "5" "Return"\
+ "4" "Return"\
  3>&1 1>&2 2>&3)
 
  clear
@@ -45,10 +44,6 @@ Close this terminal to complete updates." 7 50
 ;;
 
 4)
-/xDrip/scripts/update_FreeDNSCredentials.sh
-;;
-
-5)
 ;;
 
 esac

--- a/menu_GC_Setup.sh
+++ b/menu_GC_Setup.sh
@@ -12,10 +12,8 @@ Press Enter to execute the highlighted option.\n" 17 50 7\
  "1" "Install Nightscout phase 1 - 15 minutes"\
  "2" "Install Nightscout phase 2 - 5 minutes"\
  "3" "Update platform"\
- "4" "Bootstrap the stable release"\
- "5" "Bootstrap the dev. release (advanced)"\
- "6" "Enter FreeDNS ID and password"\
- "7" "Return"\
+ "4" "Enter FreeDNS ID and password"\
+ "5" "Return"\
  3>&1 1>&2 2>&3)
 
  clear
@@ -47,18 +45,10 @@ Close this terminal to complete updates." 7 50
 ;;
 
 4)
-curl https://raw.githubusercontent.com/jamorham/nightscout-vps/vps-1/bootstrap.sh | bash
-;;
-
-5)
-curl https://raw.githubusercontent.com/jamorham/nightscout-vps/vps-dev/bootstrap.sh | bash
-;;
-
-6)
 /xDrip/scripts/update_FreeDNSCredentials.sh
 ;;
 
-7)
+5)
 ;;
 
 esac


### PR DESCRIPTION
After we release Ubuntu 24, it will be in a new branch.  
The bootstrap in the new branch can only run on Ubuntu 24.
So, if someone who is running Ubuntu 20, attempts to run the Ubuntu 24 bootstrap from the new branch on their existing machine, the bootstrap will refuse to run.

We will be using our dev branch in the future as we have been using it.  So, it the future, we will have Ubuntu 24 in the dev branch as well as in the new branch.

Currently, before this PR, we have the option of running the bootstrap from the dev branch as a menu item.
If someone uses that menu item in the future, after we update our dev branch to Ubuntu 24, it will fail.
A menu item should not fail.

This PR removes the bootstrap options from the menu.  Users will still be able to run whatever bootstrap they desire manually.

We also have an item in the menu that allows user to update their FreeDNS user ID and password in the platform.  But, this menu item is really redundant because the user can accomplish the same by just running phase 2.
This PR removes this redundant menu item as well.

The last change this PR makes is to update the data on the status page.

I have not tested this yet as it is extremely simple and it is a PR into the dev branch.
I will test it after it is merged into the dev branch.