### PR TITLE
Mongo setup fix

### DIFF
--- a/NS_Install.sh
+++ b/NS_Install.sh
@@ -36,7 +36,12 @@ swapon 2>/dev/null /var/SWAP
 
 apt-get update
 
-cd /srv
+# Create mongo user and admin.
+wait  # Wait for all background processes to complete
+echo -e "use Nightscout\ndb.createUser({user: \"username\", pwd: \"password\", roles:[\"readWrite\"]})\nquit()" | mongosh 
+wait  # Wait for all background processes to complete
+echo -e "use admin\ndb.createUser({ user: \"mongoadmin\" , pwd: \"mongoadmin\", roles: [\"userAdminAnyDatabase\", \"dbAdminAnyDatabase\", \"readWriteAnyDatabase\"]})\nquit()" | mongosh 
+cd /srv 
 
 echo "Installing Nightscout"
 cd "$(< repo)" 

--- a/NS_Install2.sh
+++ b/NS_Install2.sh
@@ -41,7 +41,6 @@ fi
 service nginx start
 
 systemctl daemon-reload
-systemctl start mongod
 
 echo
 echo "Setting up startup service"

--- a/Status.sh
+++ b/Status.sh
@@ -205,7 +205,7 @@ Disk size: $disksz        $DiskUsedPercent used \n\
 Ubuntu: $ubuntu \n\
 HTTP & HTTPS:  $http \n\
 ------------------------------------------ \n\
-Google Cloud Nightscout  2025.02.04\n\
+Google Cloud Nightscout  2025.02.10\n\
 $apisec_problem $Missing $Phase1 $rclocal_1 $freedns_id_pass \n\n\
 /$uname/$repo/$branch\n\
 Swap: $swap \n\

--- a/update_packages.sh
+++ b/update_packages.sh
@@ -22,17 +22,8 @@ whichpack=$(which gpg)
 if [ "$whichpack" = "" ]
 then
   sudo apt-get -y install jq net-tools gnupg
+  # The last item on the above list of packages must be verified in Status.sh to have been installed.
 fi 
-
-# node - We install version 16 of node here, which automatically  updates npm to 8.
-whichpack=$(node -v)
-if [ ! "${whichpack%%.*}" = "v16" ]
-then
-sudo /xDrip/scripts/nodesource_setup.sh
-sudo apt-get install nodejs -y
-# Nightscout needs version 6 of npm.  So, we are going to install that version now effectivwely downgrading it.  
-sudo npm install -g npm@6.14.18
-fi
 
 # mongo
 whichpack="$(mongod --version | sed -n 1p)"
@@ -50,16 +41,20 @@ then
   echo "mongodb-org-mongos hold" | sudo dpkg --set-selections
   echo "mongodb-org-tools hold" | sudo dpkg --set-selections
 
-  sudo systemctl start mongod
-  sudo systemctl enable mongod
-
-  # Create mongo user and admin.
-  echo -e "use Nightscout\ndb.createUser({user: \"username\", pwd: \"password\", roles:[\"readWrite\"]})\nquit()" | mongosh
-  echo -e "use admin\ndb.createUser({ user: \"mongoadmin\" , pwd: \"mongoadmin\", roles: [\"userAdminAnyDatabase\", \"dbAdminAnyDatabase\", \"readWriteAnyDatabase\"]})\nquit()" | mongosh
+  systemctl start mongod
+  systemctl enable mongod
 
 fi
 
-# The last item on the above list of packages must be verified in Status.sh to have been installed.  
+# node - We install version 16 of node here, which automatically  updates npm to 8.
+whichpack=$(node -v)
+if [ ! "${whichpack%%.*}" = "v16" ]
+then
+sudo /xDrip/scripts/nodesource_setup.sh
+sudo apt-get install nodejs -y
+# Nightscout needs version 6 of npm.  So, we are going to install that version now effectivwely downgrading it.  
+sudo npm install -g npm@6.14.18
+fi
 
 # Add log
 /xDrip/scripts/AddLog.sh "The packages have been installed" /xDrip/Logs


### PR DESCRIPTION
The main fix thanks to you, @tzachi-dar , for finding it is the addition of wait before creating the Nightscout database and admin user.  

While I was experimenting moving commands around in order to speed up phase 1, I had changed the order of installation of Mongo and Node. I have changed that order back to the way it is in our current setup because I see no reason to change it.

Starting Mongo in phase 2 is another command that seem to be redundant because we start it already in phase 1.  So, I have removed it.