### PR TITLE
Retire ubuntu20 pr

### DIFF
--- a/Status.sh
+++ b/Status.sh
@@ -204,6 +204,9 @@ Disk size: $disksz        $DiskUsedPercent used \n\
 Ubuntu: $ubuntu \n\
 HTTP & HTTPS:  $http \n\
 ------------------------------------------ \n\
+This setup is no longer being updated.  
+Please refer to the guide or contact us to upgrade to the latest release on Ubuntu 24.  
+------------------------------------------ \n\
 Google Cloud Nightscout  2024.12.19\n\
 $apisec_problem $Missing $Phase1 $rclocal_1 $freedns_id_pass \n\n\
 /$uname/$repo/$branch\n\
@@ -214,7 +217,7 @@ Mongo: $mongo \n\
 NS proc: $ns \n\
 FreeDNS name and IP: $FD \n\
 Certificate: $cert \
- " 32 50 3\
+ " 36 50 3\
  "1" "Return"\
  "2" "Login credentials"\
  3>&1 1>&2 2>&3)

--- a/Status.sh
+++ b/Status.sh
@@ -204,8 +204,8 @@ Disk size: $disksz        $DiskUsedPercent used \n\
 Ubuntu: $ubuntu \n\
 HTTP & HTTPS:  $http \n\
 ------------------------------------------ \n\
-This setup is no longer being updated.  
-Please refer to the guide or contact us to upgrade to the latest release on Ubuntu 24.  
+Ubuntu 20 is no longer supported. \n\
+Follow the guide or contact us to upgrade to Ubuntu 24 and receive the latest updates. \n\
 ------------------------------------------ \n\
 Google Cloud Nightscout  2024.12.19\n\
 $apisec_problem $Missing $Phase1 $rclocal_1 $freedns_id_pass \n\n\

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -65,7 +65,7 @@ sudo git clone https://github.com/jamorham/nightscout-vps.git  # ✅✅✅✅✅
 ls > /tmp/repo
 sudo mv -f /tmp/repo .    # The repository name is now in /srv/repo
 cd "$(< repo)"
-sudo git checkout vps-dev  # ✅✅✅✅✅ Main - Uncomment before PR.
+sudo git checkout vps-1  # ✅✅✅✅✅ Main - Uncomment before PR.
 #sudo git checkout BackupMenuImprovement_Test  # ⛔⛔⛔⛔⛔ For test - Comment out before PR.
 
 sudo git branch > /tmp/branch


### PR DESCRIPTION
This PR only changes the status page to include a note stating that our Ubuntu 20 setup is no longer being updated.

I cannot test this on Ubuntu 20 because I cannot create a virtual machine on Ubuntu 20 any longer.
But, this is what the updated status page looks like on an Ubuntu 24 machine:
<img width="387" height="536" alt="Screenshot 2025-08-13 102859" src="https://github.com/user-attachments/assets/6e36b661-6daa-476d-8d48-d501815f8de8" />  **OUTDATED**

It is a good idea to make this change as without it, there is nothing on the status page to highlight that there could be anything wrong with the setup.

