### PR TITLE
Only install Node16

### DIFF
--- a/NS_Install.sh
+++ b/NS_Install.sh
@@ -33,6 +33,10 @@ swapon 2>/dev/null /var/SWAP
 
 # Please don't add any utility installs here.  Please instead, add them to update_packages.sh.
 /xDrip/scripts/update_packages.sh
+status=$?
+if [ $status -ne 0 ]; then
+  exit $status   # stop Phase 1 immediately
+fi
 
 # Create mongo user and admin.
 /xDrip/scripts/wait_4_completion.sh

--- a/Status.sh
+++ b/Status.sh
@@ -205,7 +205,7 @@ Disk size: $disksz        $DiskUsedPercent used \n\
 Ubuntu: $ubuntu \n\
 HTTP & HTTPS:  $http \n\
 ------------------------------------------ \n\
-Google Cloud Nightscout  2025.08.20\n\
+Google Cloud Nightscout  2025.08.24\n\
 $apisec_problem $Missing $Phase1 $rclocal_1 $freedns_id_pass \n\n\
 /$uname/$repo/$branch\n\
 Swap: $swap \n\

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin"
-# curl https://raw.githubusercontent.com/Navid200/cgm-remote-monitor/Ubuntu24_04_3_Test/bootstrap.sh | bash
+# curl https://raw.githubusercontent.com/Navid200/cgm-remote-monitor/NeverInstallNode18/bootstrap.sh | bash
 
 echo 
 echo "Bootstrapping the installation files - JamOrHam - Navid200"
@@ -96,14 +96,14 @@ sudo rm -rf *
 echo
 echo "     Please be patient."
 echo
-#sudo git clone https://github.com/jamorham/nightscout-vps.git  # ✅✅✅✅✅ Main - Uncomment before PR.
-sudo git clone https://github.com/Navid200/cgm-remote-monitor.git  # ⛔⛔⛔⛔⛔ For test - Comment out before PR.
+sudo git clone https://github.com/jamorham/nightscout-vps.git  # ✅✅✅✅✅ Main - Uncomment before PR.
+#sudo git clone https://github.com/Navid200/cgm-remote-monitor.git  # ⛔⛔⛔⛔⛔ For test - Comment out before PR.
 
 ls > /tmp/repo
 sudo mv -f /tmp/repo .    # The repository name is now in /srv/repo
 cd "$(< repo)"
-#sudo git checkout vps-2  # ✅✅✅✅✅ Main - Uncomment before PR.
-sudo git checkout Ubuntu24_04_3_Test  # ⛔⛔⛔⛔⛔ For test - Comment out before PR.
+sudo git checkout vps-2  # ✅✅✅✅✅ Main - Uncomment before PR.
+#sudo git checkout NeverInstallNode18  # ⛔⛔⛔⛔⛔ For test - Comment out before PR.
 
 sudo git branch > /tmp/branch
 grep "*" /tmp/branch | awk '{print $2}' > /tmp/brnch

--- a/menu_GC_Setup.sh
+++ b/menu_GC_Setup.sh
@@ -8,7 +8,7 @@ clear
 Choice=$(dialog --colors --nocancel --nook --menu "\
         \Zr Developed by the xDrip team \Zn\n\n
 Click OK or press Enter to select the highlighted option.\n" 14 50 7\
- "1" "Install Nightscout phase 1 - 16 minutes"\
+ "1" "Install Nightscout phase 1 - 25 minutes"\
  "2" "Install Nightscout phase 2 - 10 minutes"\
  "3" "Update"\
  "4" "Return"\
@@ -43,6 +43,10 @@ else
   sudo cp -f update_scripts.sh /xDrip/scripts/. # Update the "update scripts" script. 
   /xDrip/scripts/update_scripts.sh
   /xDrip/scripts/update_packages.sh
+  status=$?
+  if [ $status -ne 0 ]; then
+    exit $status   # stop update immediately
+  fi
   /xDrip/scripts/update_packages2.sh
   /xDrip/scripts/StartUpSetup.sh
   clear

--- a/update_packages.sh
+++ b/update_packages.sh
@@ -52,18 +52,42 @@ then
 fi
 
 # node - We install version 16 of node here, which automatically  updates npm to 8.
+check_node_candidate() {
+  apt-cache policy nodejs | grep Candidate | awk '{print $2}'
+}
+
+# Function to test if candidate starts with 16
+is_node16() {
+  echo "$1" | grep -q '^16\.'
+}
+
+install_node16() {
+  candidate=$(check_node_candidate)
+  if is_node16 "$candidate"; then
+    echo "Confirmed: Node candidate is $candidate, proceeding with install."
+    sudo apt-get install -y nodejs
+    # Nightscout needs version 6 of npm.  So, we are going to install that version now effectivwely downgrading it.
+    sudo npm install -g npm@6.14.18
+    /xDrip/scripts/AddLog.sh "The packages have been installed" /xDrip/Logs
+  else
+    echo "ERROR: Node candidate is $candidate, not v16. Aborting."
+    /xDrip/scripts/AddLog.sh "The packages except Node have been installed" /xDrip/Logs
+    clear
+    dialog --colors --infobox "       \Zr Developed by the xDrip team \Zn\n\n\n\
+Node 16 install has failed.\n\
+Please run Phase 1 again.\n\n\
+Press any key to return to the main menu." 9 50
+    read -p "" -n1 -s </dev/tty
+    exit 99   # special exit code so callers know it failed
+  fi
+}
+
 whichpack=$(node -v)
-if [ ! "${whichpack%%.*}" = "v16" ]
-then
-/xDrip/scripts/wait_4_completion.sh
-sudo /xDrip/scripts/nodesource_setup.sh
-/xDrip/scripts/wait_4_completion.sh
-sudo apt-get install nodejs -y
-# Nightscout needs version 6 of npm.  So, we are going to install that version now effectivwely downgrading it.  
-sudo npm install -g npm@6.14.18
+
+if [ -z "$whichpack" ] || [ "${whichpack%%.*}" != "v16" ]; then
+  /xDrip/scripts/wait_4_completion.sh
+  sudo /xDrip/scripts/nodesource_setup.sh
+  /xDrip/scripts/wait_4_completion.sh
+  install_node16
 fi
-
-# Add log
-/xDrip/scripts/AddLog.sh "The packages have been installed" /xDrip/Logs
-
   


### PR DESCRIPTION
We have localized the node installation so that we can remove the deprecation note for Node 16.
But, the local script still accesses the internet for downloading the packages and a key.
If there is a disconnect from the internet or may be a long delay, may be the setup fails.
The problem is that then, Node installs anyway but it installs Node 18.

Nightscout cannot install on Node 18.  So, the user waits a long time for the installation that is going to be useless.
A more important problem is that after Node 18 has been installed, fixing the problem will require additional steps to switch from 18 to 16.  So, we have no choice but to ask the user to delete the virtual machine and create a new one and try again from scratch.

If the version of node that is going to be installed is not 16 for any reason, this PR interrupts the installation and informs the user that they must run phase 1 again.
This is the form that is shown to the user in that case:
<img width="415" height="161" alt="Screenshot 2025-08-24 074217" src="https://github.com/user-attachments/assets/fdef6482-c9d2-4c42-86eb-f761575e57c9" />

After the return to the main menu, the status page shows that Mongo has already been installed but node has not as shown below:  
<img width="393" height="483" alt="Screenshot 2025-08-24 074312" src="https://github.com/user-attachments/assets/4d96d215-14bd-43dc-a114-673faeaf1596" />
What's nice about this is that the user can just try phase 1 again with no need to delete the VM and recreate it.  
