### PR TITLE
VM install from Cloud Shell

### DIFF
--- a/Status.sh
+++ b/Status.sh
@@ -205,7 +205,7 @@ Disk size: $disksz        $DiskUsedPercent used \n\
 Ubuntu: $ubuntu \n\
 HTTP & HTTPS:  $http \n\
 ------------------------------------------ \n\
-Google Cloud Nightscout  2025.08.24\n\
+Google Cloud Nightscout  2025.11.03\n\
 $apisec_problem $Missing $Phase1 $rclocal_1 $freedns_id_pass \n\n\
 /$uname/$repo/$branch\n\
 Swap: $swap \n\

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin"
-# curl https://raw.githubusercontent.com/Navid200/cgm-remote-monitor/NeverInstallNode18/bootstrap.sh | bash
+# curl https://raw.githubusercontent.com/Navid200/cgm-remote-monitor/VmInstallCloudShell_Test/bootstrap.sh | bash
+
+if [[ "$CLOUD_SHELL" = true ]]; then
+  echo "You cannot run this script in Cloud Shell."
+  echo "Terminating"
+  exit 0
+fi
 
 echo 
 echo "Bootstrapping the installation files - JamOrHam - Navid200"
@@ -69,11 +75,11 @@ The Ubuntu installation option is incorrect. Please refer to the guide for detai
 fi 
 
 clear
-dialog --colors --yesno "              \Zr Google Cloud Nightscout \Zn\n\n\n\
+dialog --colors --defaultno --yesno "              \Zr Google Cloud Nightscout \Zn\n\n\
 This software and its associated online instructions are provided “as is,” without any warranties, express or implied. By using this software, you accept full responsibility and assume all risks associated with its use.\n\n\
 The developers and contributors shall not be held liable for any damages, losses, or other consequences arising from the use of this software or its documentation.\n\n\
 Before using this software, consult a qualified healthcare professional to determine its suitability for your specific needs.\n\n\
-I understand and agree." 24 62
+I understand and agree." 21 62
 response=$?
 if [ $response = 255 ] || [ $response = 1 ]
 then
@@ -102,8 +108,8 @@ sudo git clone https://github.com/jamorham/nightscout-vps.git  # ✅✅✅✅✅
 ls > /tmp/repo
 sudo mv -f /tmp/repo .    # The repository name is now in /srv/repo
 cd "$(< repo)"
-sudo git checkout vps-2  # ✅✅✅✅✅ Main - Uncomment before PR.
-#sudo git checkout NeverInstallNode18  # ⛔⛔⛔⛔⛔ For test - Comment out before PR.
+sudo git checkout vps-dev  # ✅✅✅✅✅ Main - Uncomment before PR.
+#sudo git checkout VmInstallCloudShell_Test  # ⛔⛔⛔⛔⛔ For test - Comment out before PR.
 
 sudo git branch > /tmp/branch
 grep "*" /tmp/branch | awk '{print $2}' > /tmp/brnch
@@ -164,5 +170,5 @@ fi
 /xDrip/scripts/Status.sh
 clear
 /xDrip/scripts/menu.sh
-
+  
   

--- a/create_vm.sh
+++ b/create_vm.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+set -e
+# curl https://raw.githubusercontent.com/jamorham/nightscout-vps/vps-dev/create_vm.sh | bash
+
+if [[ "$CLOUD_SHELL" != true ]]; then
+  echo "You can only run this script in Cloud Shell."
+  echo "Terminating."
+  exit 0
+fi
+
+echo
+echo "🌩️  Google Cloud Nightscout VM Installer"
+echo "----------------------------------------"
+echo "✅ Environment: Cloud Shell confirmed"
+echo
+
+# --- Check for existing VMs ---
+existing_vms=$(gcloud compute instances list --format="value(name)")
+
+if [[ -n "$existing_vms" ]]; then
+  echo "⚠️  Existing virtual machines found:"
+  echo "$existing_vms"
+  echo
+  read -p "Do you still want to create a new VM? (y/N): " confirm < /dev/tty
+  confirm=$(echo "$confirm" | tr '[:upper:]' '[:lower:]')
+  if [[ "$confirm" != "y" && "$confirm" != "yes" ]]; then
+    echo "Aborted. No new VM was created."
+    exit 0
+  fi
+fi
+
+# --- Choose VM name ---
+default_vm_name="gcns-vm"
+read -p "Enter a name for your new VM [${default_vm_name}]: " vm_name < /dev/tty
+vm_name=${vm_name:-$default_vm_name}
+
+# --- Choose region and zone ---
+regions=("us-west1" "us-central1" "us-east1")
+region=${regions[$RANDOM % ${#regions[@]}]}
+zone=$(gcloud compute zones list --filter="region:($region)" --format="value(name)" | shuf -n 1)
+
+echo
+echo "Selected region: $region"
+echo "Selected zone: $zone"
+echo
+echo "The following configuration will be used:"
+echo "  VM name: $vm_name"
+echo "  Region:  $region"
+echo "  Zone:    $zone"
+echo
+read -p "Continue and create the VM? (Y/n): " proceed < /dev/tty
+proceed=$(echo "$proceed" | tr '[:upper:]' '[:lower:]')
+if [[ "$proceed" == "n" || "$proceed" == "no" ]]; then
+  echo "Cancelled. No VM created."
+  exit 0
+fi
+
+# --- Create the VM ---
+echo
+echo "🚀 Creating VM '${vm_name}' in zone '${zone}'..."
+if ! gcloud compute instances create "$vm_name" \
+  --machine-type=e2-micro \
+  --zone="$zone" \
+  --image-project=ubuntu-os-cloud \
+  --image-family=ubuntu-minimal-2404-lts-amd64 \
+  --boot-disk-size=30GB \
+  --boot-disk-type=pd-standard \
+  --network-tier=STANDARD \
+  --tags=http-server,https-server \
+  --no-shielded-secure-boot \
+  --maintenance-policy=MIGRATE \
+  --provisioning-model=STANDARD \
+  --no-enable-display-device; then
+    echo
+    echo "❌ VM creation failed. Please check your Google Cloud quotas or permissions."
+    exit 1
+fi
+
+# --- Done ---
+echo
+echo "🎉 VM '${vm_name}' was created successfully in zone '${zone}'."
+echo
+echo "You can view and manage it in the Google Cloud Console:"
+echo "  Menu > Compute Engine > VM instances"
+echo
+
+ 


### PR DESCRIPTION
Before opening this PR, I first updated the dev branch to match our stable (vps2) branch.

This PR adds a new file, create_vm.sh.  It is the file that contains the Cloud Shell commands for creating a virtual machine.
The command that needs to be executed in Cloud Shell is the following: 
`curl https://raw.githubusercontent.com/jamorham/nightscout-vps/vps-dev/create_vm.sh | bash`  

This PR also adds a check to the bootstrap file that stops running if it detects that it is running in Cloud Shell.

When running bootstrap, an acknowledgement comes up that the user needs to approve.  It was set to yes by deffault.
This PR changes that so that it is set to No by default.  This will require the user to click on yes hopefully making them read it.

I have tested all of this here: 
https://github.com/Navid200/cgm-remote-monitor/tree/VmInstallCloudShell_Test 