### PR TITLE
Firewall fix 

### DIFF
--- a/Status.sh
+++ b/Status.sh
@@ -205,7 +205,7 @@ Disk size: $disksz        $DiskUsedPercent used \n\
 Ubuntu: $ubuntu \n\
 HTTP & HTTPS:  $http \n\
 ------------------------------------------ \n\
-Google Cloud Nightscout  2025.11.03\n\
+Google Cloud Nightscout  2025.11.14\n\
 $apisec_problem $Missing $Phase1 $rclocal_1 $freedns_id_pass \n\n\
 /$uname/$repo/$branch\n\
 Swap: $swap \n\

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -108,7 +108,7 @@ sudo git clone https://github.com/jamorham/nightscout-vps.git  # ✅✅✅✅✅
 ls > /tmp/repo
 sudo mv -f /tmp/repo .    # The repository name is now in /srv/repo
 cd "$(< repo)"
-sudo git checkout vps-dev  # ✅✅✅✅✅ Main - Uncomment before PR.
+sudo git checkout vps-2  # ✅✅✅✅✅ Main - Uncomment before PR.
 #sudo git checkout VmInstallCloudShell_Test  # ⛔⛔⛔⛔⛔ For test - Comment out before PR.
 
 sudo git branch > /tmp/branch

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -108,7 +108,7 @@ sudo git clone https://github.com/jamorham/nightscout-vps.git  # ✅✅✅✅✅
 ls > /tmp/repo
 sudo mv -f /tmp/repo .    # The repository name is now in /srv/repo
 cd "$(< repo)"
-sudo git checkout vps-2  # ✅✅✅✅✅ Main - Uncomment before PR.
+sudo git checkout vps-dev  # ✅✅✅✅✅ Main - Uncomment before PR.
 #sudo git checkout VmInstallCloudShell_Test  # ⛔⛔⛔⛔⛔ For test - Comment out before PR.
 
 sudo git branch > /tmp/branch

--- a/create_vm.sh
+++ b/create_vm.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-# curl https://raw.githubusercontent.com/jamorham/nightscout-vps/vps-dev/create_vm.sh | bash
+# curl https://raw.githubusercontent.com/jamorham/nightscout-vps/vps-2/create_vm.sh | bash
 
 if [[ "$CLOUD_SHELL" != true ]]; then
   echo "You can only run this script in Cloud Shell."

--- a/create_vm.sh
+++ b/create_vm.sh
@@ -55,8 +55,35 @@ if [[ "$proceed" == "n" || "$proceed" == "no" ]]; then
   exit 0
 fi
 
-# --- Create the VM ---
+# --- Ensure firewall rules for HTTP and HTTPS exist ---
 echo
+echo "Checking firewall rules..."
+for rule in default-allow-http default-allow-https; do
+  if ! gcloud compute firewall-rules describe "$rule" --quiet >/dev/null 2>&1; then
+    if [[ "$rule" == "default-allow-http" ]]; then
+      echo "Creating firewall rule for HTTP (tcp:80)..."
+      gcloud compute firewall-rules create default-allow-http \
+        --allow tcp:80 \
+        --target-tags=http-server \
+        --description="Allow HTTP traffic" \
+        --direction=INGRESS \
+        --priority=1000 \
+        --network=default
+    else
+      echo "Creating firewall rule for HTTPS (tcp:443)..."
+      gcloud compute firewall-rules create default-allow-https \
+        --allow tcp:443 \
+        --target-tags=https-server \
+        --description="Allow HTTPS traffic" \
+        --direction=INGRESS \
+        --priority=1000 \
+        --network=default
+    fi
+  fi
+done
+echo
+
+# --- Create the VM ---
 echo "🚀 Creating VM '${vm_name}' in zone '${zone}'..."
 if ! gcloud compute instances create "$vm_name" \
   --machine-type=e2-micro \


### PR DESCRIPTION
If you want to recreate the problem, create a new Google Cloud project.
Then, before ever creating a virtual machine in it manually, use our script in the Cloud Shell to create a new virtual machine in it.
Now, go to VM instances and click on the new VM name to see the details.  Scroll down to see the http and https firewalls.  You will see that they are off.
This is why running phase 2 fails as reported here: https://github.com/NightscoutFoundation/xDrip/discussions/4241


This PR only updates the virtual machine creation script.
It now verifies that the firewalls are enabled in the project.  If they are not, it enables them.
If the firewalls are already active, which will be the case if someone has deleted an existing virtual machine and are creating another in the same project, it will just behave as it did before.  

This will guarantee that firewalls will be enabled when someone uses our script for creating a new virtual machine in a brand new Google Cloud project.

This PR also updates the date on the status page.