### PR TITLE
Small terminal warning

### DIFF
--- a/ConfigureFreedns.sh
+++ b/ConfigureFreedns.sh
@@ -22,7 +22,7 @@ do
 go_back=0
 clear
 exec 3>&1
-Values=$(dialog --colors --ok-label "Submit" --form "       \Zr Developed by the xDrip team \Zn\n\n\n\
+Values=$(dialog --colors --ok-label "Submit" --form "         \Zr Google Cloud Nightscout \Zn\n\n\n\
 Enter your FreeDNS user ID and password to establish a hostname, or press ESC if you already have a working hostname to keep it unchanged." 14 50 0 "User ID:" 1 1 "$user" 1 14 25 0 "Password:" 2 1 "$pass" 2 14 25 0 2>&1 1>&3)
 response=$?
 if [ $response = 255 ] || [ $response = 1 ] # cancled or escaped
@@ -37,7 +37,7 @@ pass=$(echo "$Values" | sed -n 2p)
 
 if [[ "$user" =~ [A-Z] ]]
 then
-dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
+dialog --colors --msgbox "         \Zr Google Cloud Nightscout \Zn\n\n\
 Your FreeDNS user ID does not include uppercase letters. Although FreeDNS does not notify you, it automatically converts all uppercase letters in your user ID to lowercase.\n\n\
 To verify your user ID, log in to FreeDNS and check the main menu. Your approved user ID is displayed at the top of the right pane.\n\n\
 Please try again." 16 50
@@ -50,7 +50,7 @@ if [ "$user" = "" ] || [ "$pass" = "" ] #  At least one parameter is blank.
 then
   go_back=1
   clear
-  dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
+  dialog --colors --msgbox "         \Zr Google Cloud Nightscout \Zn\n\n\
 You need to enter both your user ID and password. Please try again."  8 50
 fi
 clear
@@ -64,7 +64,7 @@ then
   wget -O /tmp/hosts "$arg"
 if [ ! "`grep 'Could not authenticate' /tmp/hosts`" = "" ] # Failed to log in
 then
-  dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nFailed to authenticate.  Please try again."  7 50
+  dialog --colors --msgbox "         \Zr Google Cloud Nightscout \Zn\n\nFailed to authenticate.  Please try again."  7 50
   go_back=1
 fi
 
@@ -73,14 +73,14 @@ then
   Lines=$(awk 'END{print NR}' /tmp/hosts)
   if [ $Lines -eq 0 ] # No hostnames # if 5
   then
-    dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nNo subdomains were found. Please ensure you have at least one in your FreeDNS account and try again."  8 50
+    dialog --colors --msgbox "         \Zr Google Cloud Nightscout \Zn\n\nNo subdomains were found. Please ensure you have at least one in your FreeDNS account and try again."  8 50
     go_back=1
 
   elif [ $Lines -gt 1 ] # More than one hostname
   then
     clear
     exec 3>&1
-    subvalue=$(dialog --colors --ok-label "Submit" --form "       \Zr Developed by the xDrip team \Zn\n\n\nYou have more than one subdomain. Please enter the subdomain you wish to use. \nIt should follow the format: mine.strangled.net"  13 50 0 "Subdomain:" 1 1 "$subd" 1 14 25 0 2>&1 1>&3)
+    subvalue=$(dialog --colors --ok-label "Submit" --form "         \Zr Google Cloud Nightscout \Zn\n\n\nYou have more than one subdomain. Please enter the subdomain you wish to use. \nIt should follow the format: mine.strangled.net"  13 50 0 "Subdomain:" 1 1 "$subd" 1 14 25 0 2>&1 1>&3)
     response2=$?
     if [ $response2 = 255 ] || [ $response2 = 1 ] # canceled or escaped
     then
@@ -95,7 +95,7 @@ then
       then
         go_back=1
         clear
-        dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nYou need to enter a subdomain. Please try again."  7 50
+        dialog --colors --msgbox "         \Zr Google Cloud Nightscout \Zn\n\nYou need to enter a subdomain. Please try again."  7 50
       fi
 
       if [ $go_back -lt 1 ] # if 3
@@ -104,7 +104,7 @@ then
         if [ ! -s /tmp/FullLine ] # Not found
         then
           go_back=1
-          dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\nThe subdomain you entered does not match any of the ones we found. Please try again." 9 50
+          dialog --colors --msgbox "         \Zr Google Cloud Nightscout \Zn\n\n\nThe subdomain you entered does not match any of the ones we found. Please try again." 9 50
         fi
         if [ $go_back -lt 1 ]  # if 2
         then
@@ -112,7 +112,7 @@ then
         if [ $Lines2 -gt 1 ] # More than one found  if 1
         then
           go_back=1
-          dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\nThe value you entered matches more than one of your subdomains. Please try again and enter a unique value." 10 50
+          dialog --colors --msgbox "         \Zr Google Cloud Nightscout \Zn\n\n\nThe value you entered matches more than one of your subdomains. Please try again and enter a unique value." 10 50
         else
           FLine=$(</tmp/FullLine)
           got_them=1 # We have the hostname and direct URL
@@ -161,7 +161,7 @@ EOF
 # Start the first update immediately
 wget -O - --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 $directurl
 
-dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
+dialog --colors --msgbox "         \Zr Google Cloud Nightscout \Zn\n\n\
 Press Enter to proceed. Please be patient, as this may take up to 10 minutes to complete." 8 50
 clear
 # wait for the ip to be updated. This might take up to 10 minutes.
@@ -184,7 +184,7 @@ while : ; do
     if [ $cnt -gt 20 ]
     then
       clear
-      dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
+      dialog --colors --msgbox "         \Zr Google Cloud Nightscout \Zn\n\n\
 Please close this window and open a new SSH terminal. Then, run Installation Phase 2 again to complete the configuration." 9 50
       exit
     fi
@@ -215,10 +215,10 @@ cat > /tmp/FreeDNS_Failed << EOF
 Internal error.  Must run FreeDNS again.
 EOF
 
-dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nInternal error. Press Enter to exit, then run \"Install Phase 2\" again." 8 50
+dialog --colors --msgbox "         \Zr Google Cloud Nightscout \Zn\n\nInternal error. Press Enter to exit, then run \"Install Phase 2\" again." 8 50
 
 else  # If FreeDNS is down
-dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
+dialog --colors --msgbox "         \Zr Google Cloud Nightscout \Zn\n\n\
 It seems the FreeDNS site is currently down. Please try again once FreeDNS is back up." 9 50
 cat > /tmp/FreeDNS_Failed << EOF
 The FreeDNS site is down.

--- a/NS_Install.sh
+++ b/NS_Install.sh
@@ -12,7 +12,7 @@ exit 5
 fi
 
 clear
-dialog --colors --msgbox "      \Zr Developed by the xDrip team \Zn\n\n\
+dialog --colors --msgbox "          \Zr Google Cloud Nightscout \Zn\n\n\
 The required packages will now be installed.  This process will take approximately 16 minutes to complete.  Please keep this terminal open during the installation.  Press Enter to proceed.\n\n\
 If this is not a convenient time, press ESC to cancel." 14 50
 if [ $? = 255 ]

--- a/NS_Install.sh
+++ b/NS_Install.sh
@@ -12,7 +12,7 @@ exit 5
 fi
 
 clear
-dialog --colors --msgbox "          \Zr Google Cloud Nightscout \Zn\n\n\
+dialog --colors --msgbox "         \Zr Google Cloud Nightscout \Zn\n\n\
 The required packages will now be installed.  This process will take approximately 16 minutes to complete.  Please keep this terminal open during the installation.  Press Enter to proceed.\n\n\
 If this is not a convenient time, press ESC to cancel." 14 50
 if [ $? = 255 ]

--- a/NS_Install2.sh
+++ b/NS_Install2.sh
@@ -7,8 +7,8 @@ echo
 if [ "$(node -v)" = "" ] # If Node.js is not installed
 then
 clear
-dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
-You need to complete install Nightscout phase 1 first." 9 50
+dialog --colors --msgbox "         \Zr Google Cloud Nightscout \Zn\n\n\
+Nightscout Phase 1 installation must be completed before you can run Phase 2." 9 50
 exit
 fi
 
@@ -98,7 +98,7 @@ do
 go_back=0
 clear
 exec 3>&1
-Value=$(dialog --colors --ok-label "Submit" --form "       \Zr Developed by the xDrip team \Zn\n\n\n\
+Value=$(dialog --colors --ok-label "Submit" --form "         \Zr Google Cloud Nightscout \Zn\n\n\n\
 API_SECRET:   $cs\n\n\
 Press ESC to keep it, or enter a new API_SECRET with at least 12 characters, excluding the following characters.\n\
   $   \"   '   \\   SPACE   @   / % " 16 50 0 "API_SECRET:" 1 1 "$secr" 1 14 25 0 2>&1 1>&3)
@@ -116,7 +116,7 @@ if [ ${#ns} -lt 12 ] # Reject if the submission has less than 12 characters.
 then
   go_back=1
   clear
-  dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
+  dialog --colors --msgbox "         \Zr Google Cloud Nightscout \Zn\n\n\
 API_SECRET must be at least 12 characters long. Please try again."  8 50
 fi
 clear
@@ -127,7 +127,7 @@ then
   then
     go_back=1
     clear
-    dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
+    dialog --colors --msgbox "         \Zr Google Cloud Nightscout \Zn\n\n\
 API_SECRET should not contain the following characters. Please try again.\n $  \"  \\  '  SPACE  @  / %"  9 50
   else
     got_it=1

--- a/Status.sh
+++ b/Status.sh
@@ -194,9 +194,23 @@ fi
 # Show the first line of last reboot
 LastReboot=$(last reboot | head -1 | awk '{print $4, "", $5, $6, $7}')
 
+# Check window size
+while true; do
+  rows=$(tput lines)
+  cols=$(tput cols)
+  if (( rows > 37 && cols > 72 )); then
+    break
+  fi
+  clear
+  dialog --colors --msgbox "         \Zr Google Cloud Nightscout \Zn\n\n\
+Terminal window is too small to display the status page.\n\n\
+Current size : ${cols} x ${rows} \n\
+Minimum size : 73 x 38 \n\n\
+Please enlarge your terminal window, then press ENTER to retry." 15 50
+done
+
 clear
-Choice=$(dialog --colors --nocancel --nook --menu "\
-        \Zr Developed by the xDrip team \Zn\n\n\
+Choice=$(dialog --colors --nocancel --nook --menu "          \Zr Google Cloud Nightscout \Zn\n\n\
                 \Zb Status \Zn\n\n\
 Zone: $Zone \n\
 RAM: $Ramsize \n\
@@ -205,7 +219,7 @@ Disk size: $disksz        $DiskUsedPercent used \n\
 Ubuntu: $ubuntu \n\
 HTTP & HTTPS:  $http \n\
 ------------------------------------------ \n\
-Google Cloud Nightscout  2025.11.03\n\
+Google Cloud Nightscout  2025.11.18\n\
 $apisec_problem $Missing $Phase1 $rclocal_1 $freedns_id_pass \n\n\
 /$uname/$repo/$branch\n\
 Swap: $swap \n\
@@ -227,7 +241,7 @@ exit
 ;;
 
 2)
-dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
+dialog --colors --msgbox "         \Zr Google Cloud Nightscout \Zn\n\n\
               \Zb\Z1Keep private!\Zn\n\n\
 Hostname:  $HOSTNAME\n\
 API_SECRET: $apisec\n\n\

--- a/backupmongo.sh
+++ b/backupmongo.sh
@@ -7,7 +7,7 @@ echo
 while :
 do
 exec 3>&1
-Filename=$(dialog --colors --ok-label "Submit" --form "       \Zr Developed by the xDrip team \Zn\n\n\
+Filename=$(dialog --colors --ok-label "Submit" --form "         \Zr Google Cloud Nightscout \Zn\n\n\
 Enter a name for the backup file and submit." 9 50 0 "file name" 1 1 "$filename" 1 14 25 0 2>&1 1>&3)
  response=$?
 if [ $response = 255 ] || [ $response = 1 ]
@@ -18,7 +18,7 @@ fi
 
 if [ -s $Filename ]
 then
-dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\n\
+dialog --colors --msgbox "         \Zr Google Cloud Nightscout \Zn\n\n\n\
 A file with the same name exists.\n\
 Choose a different filename." 9 50
 clear
@@ -29,7 +29,7 @@ cd /tmp
 cp /etc/nsconfig .
 tar -cf ~/$Filename database.gz nsconfig
 
- dialog --colors --infobox "       \Zr Developed by the xDrip team \Zn\n\n\n\
+ dialog --colors --infobox "         \Zr Google Cloud Nightscout \Zn\n\n\n\
 Backup is complete.\n\n\
 Copy the full path to the backup file shown below, and click \"DOWNLOAD FILE\" above to download it.\n\n\
 Press any key to return to the main menu." 13 50

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin"
-# curl https://raw.githubusercontent.com/Navid200/cgm-remote-monitor/VmInstallCloudShell_Test/bootstrap.sh | bash
+# curl https://raw.githubusercontent.com/Navid200/cgm-remote-monitor/SmallWindowWarning_Test/bootstrap.sh | bash
 
 if [[ "$CLOUD_SHELL" = true ]]; then
   echo "You cannot run this script in Cloud Shell."
@@ -45,7 +45,7 @@ ubversion="$(cat /etc/issue | awk '{print $2}')"
 if  [[ ! "$ubversion" == "24."* ]]
 then
   clear
-  dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
+  dialog --colors --msgbox "         \Zr Google Cloud Nightscout \Zn\n\n\
 This bootstrap is intended for Ubuntu 24.  You are running it on a different version of Ubuntu.  If you intend to update your setup, there is a different recommended approach.  Please contact us for more information at https://github.com/NightscoutFoundation/xDrip/discussions." 15 50
   exit
 fi
@@ -56,7 +56,7 @@ then
 ExistingSystem=1
 
 clear
-dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
+dialog --colors --msgbox "         \Zr Google Cloud Nightscout \Zn\n\n\
 The script you are running, \"bootstrap\", is designed to initiate an installation. However, the file system does not appear to be empty.\n\n  
 If an installation already exists on this machine, pressing Enter will modify it.  If this is not your intention, please press ESC to abort." 14 50
 if [ $? -eq 255 ]
@@ -69,7 +69,7 @@ fi
 if [[ ! "$ubversion" == "24.04"* ]] || [[ ! "$(which tbl)" == "" ]] # If the selected version of ubuntu is not what we want or if the main version has been installed instead of minimal
 then
   clear
-  dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
+  dialog --colors --msgbox "         \Zr Google Cloud Nightscout \Zn\n\n\
 The Ubuntu installation option is incorrect. Please refer to the guide for detailed instructions." 9 50  
   exit
 fi 
@@ -108,8 +108,8 @@ sudo git clone https://github.com/jamorham/nightscout-vps.git  # ✅✅✅✅✅
 ls > /tmp/repo
 sudo mv -f /tmp/repo .    # The repository name is now in /srv/repo
 cd "$(< repo)"
-sudo git checkout vps-2  # ✅✅✅✅✅ Main - Uncomment before PR.
-#sudo git checkout VmInstallCloudShell_Test  # ⛔⛔⛔⛔⛔ For test - Comment out before PR.
+sudo git checkout vps-dev  # ✅✅✅✅✅ Main - Uncomment before PR.
+#sudo git checkout SmallWindowWarning_Test  # ⛔⛔⛔⛔⛔ For test - Comment out before PR.
 
 sudo git branch > /tmp/branch
 grep "*" /tmp/branch | awk '{print $2}' > /tmp/brnch
@@ -156,11 +156,11 @@ fi
 if [ "$ExistingSystem" = "0" ]  # If this is a new installation.
 then
   clear
-  dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
+  dialog --colors --msgbox "         \Zr Google Cloud Nightscout \Zn\n\n\
 If any item above the line on the status page (shown next) is red, it indicates an incorrect parameter that could lead to malfunction or additional costs.  Please take note of the issue, delete the virtual machine, and create a new one. For more details, refer to the guide." 13 50
 else # If this is an existing installation.
   clear
-  dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nBootstrap is complete.  Press Enter to proceed to the status page." 8 50
+  dialog --colors --msgbox "         \Zr Google Cloud Nightscout \Zn\n\nBootstrap is complete.  Press Enter to proceed to the status page." 8 50
 fi
 
 # Add log 

--- a/menu.sh
+++ b/menu.sh
@@ -8,8 +8,7 @@ while :
 do
 
 clear
-Choice=$(dialog --colors --nocancel --help-button --menu "\
-        \Zr Developed by the xDrip team \Zn\n\n
+Choice=$(dialog --colors --nocancel --help-button --menu "          \Zr Google Cloud Nightscout \Zn\n\n
 Click OK or press Enter to select the highlighted option.\n\n" 18 50 8\
  "1" "Status (may take up to 2 minutes.)"\
  "2" "Logs"\
@@ -33,7 +32,7 @@ Click OK or press Enter to select the highlighted option.\n\n" 18 50 8\
    printf '\e[1;44m%-6s\e[m' " "
    printf '                                                    \n'
    printf '\e[1;44m%-6s\e[m' " "
-   printf '           Developed by the xDrip team              \n'
+   printf '             Google Cloud Nightscout              \n'
    printf '\e[1;44m%-6s\e[m' " "
    printf '                                                    \n'
    printf '\e[1;44m%-6s\e[m' " "
@@ -45,15 +44,15 @@ Click OK or press Enter to select the highlighted option.\n\n" 18 50 8\
    printf '\e[1;44m%-6s\e[m' " "
    printf '                                                    \n'
    printf '\e[1;44m%-6s\e[m' " "
-   printf '   \e]8;;https://navid200.github.io/xDrip/docs/Nightscout/GCNS/Tips.html\e\\ Tips \e]8;;\e\\                                           \n'
+   printf '   \e]8;;https://google-cloud-nightscout.github.io/docs/GCNS/Tips.html\e\\ Tips \e]8;;\e\\                                           \n'
    printf '\e[1;44m%-6s\e[m' " "
    printf '                                                    \n'
    printf '\e[1;44m%-6s\e[m' " "
-   printf '   \e]8;;https://navid200.github.io/xDrip/docs/Nightscout/GCNS/FAQ.html\e\\ FAQ \e]8;;\e\\                                            \n'
+   printf '   \e]8;;https://google-cloud-nightscout.github.io/docs/GCNS/FAQ.html\e\\ FAQ \e]8;;\e\\                                            \n'
    printf '\e[1;44m%-6s\e[m' " "
    printf '                                                    \n'
    printf '\e[1;44m%-6s\e[m' " "
-   printf '   \e]8;;https://navid200.github.io/xDrip/docs/Nightscout/GCNS/Troubleshooting.html\e\\ Troubleshooting \e]8;;\e\\                                \n'
+   printf '   \e]8;;https://google-cloud-nightscout.github.io/docs/GCNS/Troubleshooting.html\e\\ Troubleshooting \e]8;;\e\\                                \n'
    printf '\e[1;44m%-6s\e[m' " "
    printf '                                                    \n'
    printf '\e[1;44m%-6s\e[m' " "
@@ -73,7 +72,7 @@ case $Choice in
 ;;
 
 2)
-dialog --colors --title "\Zr Developed by the xDrip team \Zn"   --textbox /xDrip/Logs 26 74 
+dialog --colors --title "  \Zr Google Cloud Nightscout \Zn"   --textbox /xDrip/Logs 26 74 
 ;;
 
 3)
@@ -93,7 +92,7 @@ dialog --colors --title "\Zr Developed by the xDrip team \Zn"   --textbox /xDrip
 ;;
 
 7)
-dialog --colors --yesno "       \Zr Developed by the xDrip team \Zn\n\n\
+dialog --colors --yesno "         \Zr Google Cloud Nightscout \Zn\n\n\
 Are you sure you want to reboot the server?\n
 If you do, all unsaved open files will close without saving.\n"  9 50
 response=$?
@@ -108,7 +107,7 @@ fi
 8)
 cd /tmp
 clear
-dialog --colors --msgbox "        \Zr Developed by the xDrip team \Zn\n\n\
+dialog --colors --msgbox "          \Zr Google Cloud Nightscout \Zn\n\n\
 You will now exit to the shell (terminal).  To return to the menu, enter \"menu\" in the terminal without the quotes." 9 50
 clear
 exit

--- a/menu_Data.sh
+++ b/menu_Data.sh
@@ -5,8 +5,7 @@ echo "Bringing up the Data menu" - Navid200
 echo
 
 clear
-Choice=$(dialog --colors --nocancel --nook --menu "\
-        \Zr Developed by the xDrip team \Zn\n\n\
+Choice=$(dialog --colors --nocancel --nook --menu "          \Zr Google Cloud Nightscout \Zn\n\n\
 Click OK or press Enter to select the highlighted option.\n" 14 50 4\
  "1" "Copy data from another Nightscout"\
  "2" "Backup MongoDB and variables"\

--- a/menu_GC_Setup.sh
+++ b/menu_GC_Setup.sh
@@ -5,8 +5,7 @@ echo "Bringing up the Google Cloud menu" - Navid200
 echo
 
 clear
-Choice=$(dialog --colors --nocancel --nook --menu "\
-        \Zr Developed by the xDrip team \Zn\n\n
+Choice=$(dialog --colors --nocancel --nook --menu "          \Zr Google Cloud Nightscout \Zn\n\n
 Click OK or press Enter to select the highlighted option.\n" 14 50 7\
  "1" "Install Nightscout phase 1 - 25 minutes"\
  "2" "Install Nightscout phase 2 - 10 minutes"\
@@ -27,7 +26,7 @@ sudo /xDrip/scripts/NS_Install2.sh
 ;;
 
 3)
-dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
+dialog --colors --msgbox "         \Zr Google Cloud Nightscout \Zn\n\n\
 This will update your server and Nightscout to the latest available versions.  Press Enter to proceed or ESC to cancel."  9 50
 response=$?
 if [ $response = 255 ] || [ $response = 1 ]
@@ -50,7 +49,7 @@ else
   /xDrip/scripts/update_packages2.sh
   /xDrip/scripts/StartUpSetup.sh
   clear
-  dialog --colors --msgbox "        \Zr Developed by the xDrip team \Zn\n\n\
+  dialog --colors --msgbox "          \Zr Google Cloud Nightscout \Zn\n\n\
 Close this SSH window to complete updates." 7 50
 fi
 ;;

--- a/menu_NS_setup.sh
+++ b/menu_NS_setup.sh
@@ -5,8 +5,7 @@ echo "Bringing up the Nightscout setup menu" - Navid200
 echo
 
 clear
-Choice=$(dialog --colors --nocancel --nook --menu "\
-        \Zr Developed by the xDrip team \Zn\
+Choice=$(dialog --colors --nocancel --nook --menu "          \Zr Google Cloud Nightscout \Zn\
   \n\n
 Click OK or press Enter to select the highlighted option.\n" 14 50 4\
  "1" "Edit variables using a text editor"\

--- a/menu_xDripSetup.sh
+++ b/menu_xDripSetup.sh
@@ -5,8 +5,7 @@ echo "Bringing up the utilities menu" - Navid200
 echo
 
 clear
-Choice=$(dialog --colors --nocancel --nook --menu "\
-        \Zr Developed by the xDrip team \Zn\n\n\
+Choice=$(dialog --colors --nocancel --nook --menu "          \Zr Google Cloud Nightscout \Zn\n\n\
 Click OK or press Enter to select the highlighted option.\n" 12 50 2\
  "1" "QR code to make xDrip master"\
  "2" "Return"\

--- a/qrCodeMaster.sh
+++ b/qrCodeMaster.sh
@@ -13,7 +13,7 @@ apisec=$API_SECRET
 if [ "$(node -v)" = "" ] || [ "$HOSTNAME" = "" ] || [ "$apisec" = "" ] # If Node.js is not installed or there is no hostname or password
 then
 clear
-dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
+dialog --colors --msgbox "         \Zr Google Cloud Nightscout \Zn\n\n\
 You need to complete the Nightscout installation and have both a hostname and API_SECRET in order to display the QR code for setting up xDrip as an uploader." 10 50
 exit
 fi
@@ -21,7 +21,7 @@ fi
 baseurl="https://$apisec@$HOSTNAME/api/v1/" 
 
 clear
-echo "      Developed by the xDrip team"
+echo "        Google Cloud Nightscout"
 echo ""
 echo ""
 echo "You have 2 options for setting up xDrip as your uploader."

--- a/reboot.sh
+++ b/reboot.sh
@@ -6,7 +6,6 @@ echo
 
 clear
 sudo reboot
-dialog --colors --no-cancel --ok-label "Please wait" --pause "       \Zr Developed by the xDrip team \Zn\n\n\
+dialog --colors --no-cancel --ok-label "Please wait" --pause "         \Zr Google Cloud Nightscout \Zn\n\n\
 Please wait 25 seconds for the system to reboot. An expected error message will then appear. Wait an additional 30 seconds before attempting to reconnect." 14 50 25
 exit 
-

--- a/restoremongo.sh
+++ b/restoremongo.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+if [ "$(node -v)" = "" ] # If Node.js is not installed
+then
+clear
+dialog --colors --msgbox "         \Zr Google Cloud Nightscout \Zn\n\n\
+Nightscout phase 1 installation must be completed before you can restore a database." 9 50
+exit
+fi
+
 while :
 do
 goback=0 # Reset the loop
@@ -16,7 +24,7 @@ echo "$File"
 if [ "$(file -b "$File")" = "directory" ] # If no file has been selected.
 then
   clear
-  dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
+  dialog --colors --msgbox "         \Zr Google Cloud Nightscout \Zn\n\n\
 Select the file in the right pane and press Space to display it in the field at the bottom. Then, click OK or press Enter.\n\
 Please try again." 11 50
 goback=1 # Don't execute the remaining part of the loop
@@ -29,7 +37,7 @@ then
     if [ ! "$(tar -tf $File 'database.gz')" = "database.gz" ] || [ ! "$(tar -tf $File 'nsconfig')" = "nsconfig" ]
     then
       clear
-      dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nThe backup file may be corrupt.  Please report this issue." 10 50
+      dialog --colors --msgbox "         \Zr Google Cloud Nightscout \Zn\n\nThe backup file may be corrupt.  Please report this issue." 10 50
       goback=1 # Don't execute the rest of the loop
     fi
     if [ $goback -eq 0 ]
@@ -40,7 +48,7 @@ then
       cd /tmp
       clear
       Choice=$(dialog --colors --nocancel --nook --menu "\
-        \Zr Developed by the xDrip team \Zn\n\n\
+        \Zr Google Cloud Nightscout \Zn\n\n\
 Click OK or press Enter to select the highlighted option.\n\n\
 Restoring variables will overwrite API_SECRET." 16 50 4\
  "1" "Restore MongoDB only"\
@@ -79,15 +87,15 @@ esac
         clear
         if [ $fail = 1 ]
         then
-          dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nThe database import failed.  Please report the issue." 8 50
+          dialog --colors --msgbox "         \Zr Google Cloud Nightscout \Zn\n\nThe database import failed.  Please report the issue." 8 50
         else # If the database was successfully imported
           echo -e "Restored MongoDB     $(date)\n" | cat - /xDrip/Logs > /tmp/Logs
           sudo /bin/cp -f /tmp/Logs /xDrip/Logs
           if [ $var -lt 1 ] # If the user chose not to restore the variables
           then
-            dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nDatabase has been imported.\nThe variables will not be restored, but you can view them at /tmp/nsconfig." 9 50
+            dialog --colors --msgbox "         \Zr Google Cloud Nightscout \Zn\n\nDatabase has been imported.\nThe variables will not be restored, but you can view them at /tmp/nsconfig." 9 50
           else # If the user chose to also restore the variables
-            dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nThe database has been successfully imported." 8 50
+            dialog --colors --msgbox "         \Zr Google Cloud Nightscout \Zn\n\nThe database has been successfully imported." 8 50
           fi
         fi
       fi
@@ -98,7 +106,7 @@ esac
         echo -e "Restored variables     $(date)\n" | cat - /xDrip/Logs > /tmp/Logs
         sudo /bin/cp -f /tmp/Logs /xDrip/Logs
         clear
-        dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nThe variables have been restored from backup.  You need to restart the server for the updated variables to take effect." 9 50
+        dialog --colors --msgbox "         \Zr Google Cloud Nightscout \Zn\n\nThe variables have been restored from backup.  You need to restart the server for the updated variables to take effect." 9 50
       fi
       exit
     fi  
@@ -110,7 +118,7 @@ then
   if [ "$(file -b "$File" | awk '{print $1}')" = "gzip" ] # If the backup file is a gzip file, we will know that it is an old backup only containing the database.
   then
     clear
-    dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
+    dialog --colors --msgbox "         \Zr Google Cloud Nightscout \Zn\n\n\
 The backup only contains a database.  Press Enter to import it." 9 50
     key=$?
     if [ $key = 255 ]
@@ -122,10 +130,10 @@ The backup only contains a database.  Press Enter to import it." 9 50
     fail=$?
     if [ $fail -eq 1 ]
     then
-      dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nThe database import failed. Please report the issue." 11 50
+      dialog --colors --msgbox "         \Zr Google Cloud Nightscout \Zn\n\nThe database import failed. Please report the issue." 11 50
       exit
     else
-      dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nThe database has been successfully imported." 8 50
+      dialog --colors --msgbox "         \Zr Google Cloud Nightscout \Zn\n\nThe database has been successfully imported." 8 50
       echo -e "Restored MongoDB     $(date)\n" | cat - /xDrip/Logs > /tmp/Logs
       sudo /bin/cp -f /tmp/Logs /xDrip/Logs
       exit

--- a/update_FreeDNSCredentials.sh
+++ b/update_FreeDNSCredentials.sh
@@ -15,7 +15,7 @@ then
   while [ $got_them -lt 1 ]
   do
   exec 3>&1
-  Values=$(dialog --colors --ok-label "Submit" --form "       \Zr Developed by the xDrip team \Zn\n\n\n\
+  Values=$(dialog --colors --ok-label "Submit" --form "         \Zr Google Cloud Nightscout \Zn\n\n\n\
 This utility lets you update your FreeDNS user ID and password in Google Cloud Nightscout.\n\
 It cannot update your user ID or password on the FreeDNS site.  To do that, you will need to use a browser and log into FreeDNS. Then, use this utility to update Google Cloud Nightscout accordingly.\n\n\
 Enter your ID and password to proceed.  Or press escape to cancel." 22 50 0 "User ID:" 1 1 "$user" 1 14 25 0 "Password:" 2 1 "$pass" 2 14 25 0 2>&1 1>&3)
@@ -34,7 +34,7 @@ Enter your ID and password to proceed.  Or press escape to cancel." 22 50 0 "Use
   wget -O /tmp/hosts "$arg"
   if [ ! "`grep 'Could not authenticate' /tmp/hosts`" = "" ] # Failed to log in
   then
-    dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\nFailed to authenticate.  Please try again."  7 50
+    dialog --colors --msgbox "         \Zr Google Cloud Nightscout \Zn\n\nFailed to authenticate.  Please try again."  7 50
   else
     got_them=1
     cat > /xDrip/FreeDNS_ID_Pass << EOF
@@ -53,10 +53,11 @@ EOF
   /xDrip/scripts/AddLog.sh "FreeDNS user ID and password have been recorded as reminders" /xDrip/Logs
   
 else # If FreeDNS is down
-  dialog --colors --msgbox "       \Zr Developed by the xDrip team \Zn\n\n\
+  dialog --colors --msgbox "         \Zr Google Cloud Nightscout \Zn\n\n\
 It seems the FreeDNS site is down.  Please try again when FreeDNS is back up." 9 50
   cat > /tmp/FreeDNS_Failed << EOF
 The FreeDNS site is down.
 EOF
 
 fi
+  

--- a/update_nightscout.sh
+++ b/update_nightscout.sh
@@ -23,7 +23,7 @@ exec 3>&1
 
 # Ask for the fork details. 
 clear
-VALUES=$(dialog --colors --ok-label "Submit" --form "       \Zr Google Cloud Nightscout \Zn\n\n Enter the GitHub details for the Nightscout version you wish to install.\n" 14 50 0 "User ID:" 1 1 "$user" 1 14 25 0 "Repository:" 2 1 "$repo" 2 14 25 0 "Branch:" 3 1 "$brnch" 3 14 25 0 2>&1 1>&3)
+VALUES=$(dialog --colors --ok-label "Submit" --form "         \Zr Google Cloud Nightscout \Zn\n\n Enter the GitHub details for the Nightscout version you wish to install.\n" 14 50 0 "User ID:" 1 1 "$user" 1 14 25 0 "Repository:" 2 1 "$repo" 2 14 25 0 "Branch:" 3 1 "$brnch" 3 14 25 0 2>&1 1>&3)
 response=$?
 if [ $response = 255 ] || [ $response = 1 ] # Exit if escaped or cancelled
 then
@@ -42,7 +42,7 @@ if [ "$user" = "" ] || [ "$repo" = "" ] || [ "$brnch" = "" ] # Abort if either p
 then
   go_back=1
   clear
-  dialog --colors --msgbox "       \Zr Google Cloud Nightscout \Zn\n\nYou need to enter all three parameters.  Please try again."  8 50
+  dialog --colors --msgbox "         \Zr Google Cloud Nightscout \Zn\n\nYou need to enter all three parameters.  Please try again."  8 50
 fi
 if [ $go_back -lt 1 ]
 then
@@ -54,7 +54,7 @@ done
 clear  # Clear the last dialog
 
 # Last chance to stop before any destructive actions.
-dialog --colors --msgbox "      \Zr Google Cloud Nightscout \Zn\n\n
+dialog --colors --msgbox "         \Zr Google Cloud Nightscout \Zn\n\n
 The installation will take about 15 minutes.  Nightscout will be down during that period.  You can cancel by pressing escape now.\n\n\
 If you proceed, you can minimize this terminal.  But, please don't close it.  After completion, the server will reboot." 13 50
 response=$?

--- a/update_nightscout.sh
+++ b/update_nightscout.sh
@@ -9,7 +9,7 @@ a=$(node -v)
 if [ "$a" = ""  ]
 then
 clear
-dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\n\
+dialog --colors --msgbox "         \Zr Google Cloud Nightscout \Zn\n\n\
 You need to complete installation phase 1 first." 9 50
 exit
 fi
@@ -23,7 +23,7 @@ exec 3>&1
 
 # Ask for the fork details. 
 clear
-VALUES=$(dialog --colors --ok-label "Submit" --form "     \Zr Developed by the xDrip team \Zn\n\n Enter the GitHub details for the Nightscout version you wish to install.\n" 14 50 0 "User ID:" 1 1 "$user" 1 14 25 0 "Repository:" 2 1 "$repo" 2 14 25 0 "Branch:" 3 1 "$brnch" 3 14 25 0 2>&1 1>&3)
+VALUES=$(dialog --colors --ok-label "Submit" --form "       \Zr Google Cloud Nightscout \Zn\n\n Enter the GitHub details for the Nightscout version you wish to install.\n" 14 50 0 "User ID:" 1 1 "$user" 1 14 25 0 "Repository:" 2 1 "$repo" 2 14 25 0 "Branch:" 3 1 "$brnch" 3 14 25 0 2>&1 1>&3)
 response=$?
 if [ $response = 255 ] || [ $response = 1 ] # Exit if escaped or cancelled
 then
@@ -42,7 +42,7 @@ if [ "$user" = "" ] || [ "$repo" = "" ] || [ "$brnch" = "" ] # Abort if either p
 then
   go_back=1
   clear
-  dialog --colors --msgbox "     \Zr Developed by the xDrip team \Zn\n\nYou need to enter all three parameters.  Please try again."  8 50
+  dialog --colors --msgbox "       \Zr Google Cloud Nightscout \Zn\n\nYou need to enter all three parameters.  Please try again."  8 50
 fi
 if [ $go_back -lt 1 ]
 then
@@ -54,7 +54,7 @@ done
 clear  # Clear the last dialog
 
 # Last chance to stop before any destructive actions.
-dialog --colors --msgbox "    \Zr Developed by the xDrip team \Zn\n\n
+dialog --colors --msgbox "      \Zr Google Cloud Nightscout \Zn\n\n
 The installation will take about 15 minutes.  Nightscout will be down during that period.  You can cancel by pressing escape now.\n\n\
 If you proceed, you can minimize this terminal.  But, please don't close it.  After completion, the server will reboot." 13 50
 response=$?

--- a/update_packages.sh
+++ b/update_packages.sh
@@ -73,7 +73,7 @@ install_node16() {
     echo "ERROR: Node candidate is $candidate, not v16. Aborting."
     /xDrip/scripts/AddLog.sh "The packages except Node have been installed" /xDrip/Logs
     clear
-    dialog --colors --infobox "       \Zr Developed by the xDrip team \Zn\n\n\n\
+    dialog --colors --infobox "         \Zr Google Cloud Nightscout \Zn\n\n\n\
 Node 16 install has failed.\n\
 Please run Phase 1 again.\n\n\
 Press any key to return to the main menu." 9 50

--- a/variables.sh
+++ b/variables.sh
@@ -4,7 +4,7 @@ echo
 echo "Nightscout variables"
 echo
 
-dialog --colors --msgbox "              \Zr Developed by the xDrip team \Zn\n\n\
+dialog --colors --msgbox "                \Zr Google Cloud Nightscout \Zn\n\n\
 You will be editing the file containing the variables.  The key combinations for text editor functions will be displayed at the bottom of the screen.\n\
 ^ represents the control key.  For example, ^X means pressing the control and x keys simultaneously.\n\n\
 To save, press Ctrl + O, then press Enter to confirm.\n\n\


### PR DESCRIPTION
1- If you make the SSH terminal window too small, and attempt to access the Status page, nothing will happen; the status page will not open and nothing will inform the user why.  

This PR changes that behavior.  In that case, a menu will appear informing the user that the window is too small showing the dimensions of the window and the minimum acceptable dimensions.  Upon resizing the window to acceptable values, pressing Return will proceed to bring up the status page.  
<img width="456" height="377" alt="Screenshot 2025-11-17 194328" src="https://github.com/user-attachments/assets/188a3bd1-53a5-4b3c-b605-3916a7e2af5a" />  
  
2- The links on the Help menu have been updated to point to the pages on the guide at its new location.  
Currently, those links point to the old site.  The old site pages all redirect to the new corresponding pages.  So, the users see no issue currently.  But, some time in the future, we will be permanently removing the old site.  When we do that, the links will be dead.  This PR addresses that and makes the links correct with no need for redirects. 

3- If you attempt to restore a database before having run phase 1, nothing will happen and the user will not see any message why.  After this PR, the user in that case will see a menu stating that database restore can only be performed after completing phase 1.

4- The title of every menu is "Developed by the xDrip team".  This PR changes that to "Google Cloud Nightscout".  
It is true that the project is developed and maintained by the xDrip team.  But, I don't know if we should state that at the top of every page.  