### PR TITLE
Mongo update

### DIFF
--- a/ConfigureFreedns.sh
+++ b/ConfigureFreedns.sh
@@ -73,7 +73,7 @@ then
   Lines=$(awk 'END{print NR}' /tmp/hosts)
   if [ $Lines -eq 0 ] # No hostnames # if 5
   then
-    dialog --colors --msgbox "         \Zr Google Cloud Nightscout \Zn\n\nNo subdomains were found. Please ensure you have at least one in your FreeDNS account and try again."  8 50
+    dialog --colors --msgbox "         \Zr Google Cloud Nightscout \Zn\n\nNo subdomains were found. Please ensure you have at least one in your FreeDNS account and try again."  9 50
     go_back=1
 
   elif [ $Lines -gt 1 ] # More than one hostname

--- a/Status.sh
+++ b/Status.sh
@@ -219,7 +219,7 @@ Disk size: $disksz        $DiskUsedPercent used \n\
 Ubuntu: $ubuntu \n\
 HTTP & HTTPS:  $http \n\
 ------------------------------------------ \n\
-Google Cloud Nightscout  2025.11.18\n\
+Google Cloud Nightscout  2026.01.05\n\
 $apisec_problem $Missing $Phase1 $rclocal_1 $freedns_id_pass \n\n\
 /$uname/$repo/$branch\n\
 Swap: $swap \n\

--- a/update_packages.sh
+++ b/update_packages.sh
@@ -27,29 +27,36 @@ then
   # The last item on the above list of packages must be verified in Status.sh to have been installed.
 fi 
 
+
 # mongo
-whichpack="$(mongod --version | sed -n 1p)"
-if [ ! "${whichpack%%.*}" = "db version v8" ]
+mongover="$(mongod --version 2>/dev/null | sed -n 's/^db version v//p' | head -n1)"
+
+if [ -z "$mongover" ] || dpkg --compare-versions "$mongover" lt "8.0.17"
 then
   /xDrip/scripts/wait_4_completion.sh
-  curl -fsSL https://www.mongodb.org/static/pgp/server-8.0.asc | sudo gpg -o /usr/share/keyrings/mongodb-server-8.0.gpg --dearmor
-  echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-8.0.gpg ] https://repo.mongodb.org/apt/ubuntu noble/mongodb-org/8.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-8.0.list   
+
+  if [ ! -f /usr/share/keyrings/mongodb-server-8.0.gpg ]; then
+    curl -fsSL https://www.mongodb.org/static/pgp/server-8.0.asc | sudo gpg --dearmor -o /usr/share/keyrings/mongodb-server-8.0.gpg
+  fi
+
+
+  echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-8.0.gpg ] https://repo.mongodb.org/apt/ubuntu noble/mongodb-org/8.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-8.0.list
   /xDrip/scripts/wait_4_completion.sh
   sudo apt-get update
-  sudo apt-get install -y mongodb-org=8.0.0 mongodb-org-database=8.0.0 mongodb-org-server=8.0.0 mongodb-mongosh mongodb-org-mongos=8.0.0 mongodb-org-tools=8.0.0
 
-  echo "mongodb-org hold" | sudo dpkg --set-selections
-  echo "mongodb-org-database hold" | sudo dpkg --set-selections
-  echo "mongodb-org-server hold" | sudo dpkg --set-selections
-  echo "mongodb-mongosh hold" | sudo dpkg --set-selections
-  echo "mongodb-org-mongos hold" | sudo dpkg --set-selections
-  echo "mongodb-org-tools hold" | sudo dpkg --set-selections
+  # allow upgrade if packages were previously held
+  sudo apt-mark unhold mongodb-org mongodb-org-database mongodb-org-server mongodb-mongosh mongodb-org-mongos mongodb-org-tools || true
+
+  sudo apt-get install -y mongodb-org=8.0.17 mongodb-org-database=8.0.17 mongodb-org-server=8.0.17 mongodb-mongosh mongodb-org-mongos=8.0.17 mongodb-org-tools=8.0.17
+
+  # re-hold to prevent unintended upgrades
+  sudo apt-mark hold mongodb-org mongodb-org-database mongodb-org-server mongodb-mongosh mongodb-org-mongos mongodb-org-tools
 
   /xDrip/scripts/wait_4_completion.sh
-  systemctl start mongod
   systemctl enable mongod
-
+  systemctl start mongod
 fi
+
 
 # node - We install version 16 of node here, which automatically  updates npm to 8.
 check_node_candidate() {


### PR DESCRIPTION
This PR upgrades Mongo in our dev branch to 8.0.17.
There is a memory leak report that suggests upgrading to 8.0.17 to address it.

I have tested this for a fresh install as well as for an update of our existing system.

<img width="390" height="472" alt="Screenshot 2026-01-05 103055" src="https://github.com/user-attachments/assets/33b11f03-0f24-41e6-a008-2937d1211da5" />  