### PR TITLE
Mongo start fix

### DIFF
--- a/Status.sh
+++ b/Status.sh
@@ -219,7 +219,7 @@ Disk size: $disksz        $DiskUsedPercent used \n\
 Ubuntu: $ubuntu \n\
 HTTP & HTTPS:  $http \n\
 ------------------------------------------ \n\
-Google Cloud Nightscout  2026.01.05\n\
+Google Cloud Nightscout  2026.01.06\n\
 $apisec_problem $Missing $Phase1 $rclocal_1 $freedns_id_pass \n\n\
 /$uname/$repo/$branch\n\
 Swap: $swap \n\

--- a/update_packages.sh
+++ b/update_packages.sh
@@ -53,8 +53,8 @@ then
   sudo apt-mark hold mongodb-org mongodb-org-database mongodb-org-server mongodb-mongosh mongodb-org-mongos mongodb-org-tools
 
   /xDrip/scripts/wait_4_completion.sh
-  systemctl enable mongod
-  systemctl start mongod
+  sudo systemctl enable mongod
+  sudo systemctl start mongod
 fi
 
 


### PR DESCRIPTION
When running our update utility to upgrade Mongo, I noticed an error message.
I ran the process line by line so that I can see what causes it.  It turns out it is because the two changed lines don't have permission to execute.

It seems that this gets sorted out later after a restart because everything seems to be working for everyone.
But, I think it is best to fix it.