### PR TITLE
Ubuntu24 04 4 pr

### DIFF
--- a/Status.sh
+++ b/Status.sh
@@ -47,7 +47,7 @@ swap="$(free -h | sed -n 3p | awk '{print $2}')"
 
 #Ubuntu version
 ubuntu="$(lsb_release -a | sed -n 2p | awk '{print $3, $4}')"
-if [ ! "$ubuntu" = "24.04.3 LTS" ]
+if [ ! "$ubuntu" = "24.04.4 LTS" ]
 then
 ubuntu="\Zb\Z1$(lsb_release -a | sed -n 2p | awk '{print $3, $4}')\Zn"
 fi
@@ -219,7 +219,7 @@ Disk size: $disksz        $DiskUsedPercent used \n\
 Ubuntu: $ubuntu \n\
 HTTP & HTTPS:  $http \n\
 ------------------------------------------ \n\
-Google Cloud Nightscout  2026.01.06\n\
+Google Cloud Nightscout  2026.02.21\n\
 $apisec_problem $Missing $Phase1 $rclocal_1 $freedns_id_pass \n\n\
 /$uname/$repo/$branch\n\
 Swap: $swap \n\

--- a/update_packages.sh
+++ b/update_packages.sh
@@ -13,7 +13,7 @@ sudo apt-get update
 
 #Ubuntu upgrade available
 NextUbuntu="$(apt-get -s upgrade | grep 'Inst base' | awk '{print $4}' | sed 's/(//')"
-if [ "$NextUbuntu" = "13ubuntu10.3" ] # Only upgrade if we have tested the next release (24.04.3)
+if [ "$NextUbuntu" = "13ubuntu10.4" ] # Only upgrade if we have tested the next release (24.04.4)
 then
   sudo apt-get -y upgrade
 fi


### PR DESCRIPTION
Ubuntu 24 has had an update and the image on Google Cloud has been updated.
Therefore, new installs will show a red line on the status page until we update.
This PR will remove the red line from the status page and allows an existing setup to be updated.

<img width="386" height="472" alt="Screenshot 2026-02-21 094406" src="https://github.com/user-attachments/assets/34c3c9dc-585e-4af6-a67d-6716a6166c1c" />
