### PR TITLE
Promote our current dev to stable

### DIFF
--- a/Status.sh
+++ b/Status.sh
@@ -47,7 +47,7 @@ swap="$(free -h | sed -n 3p | awk '{print $2}')"
 
 #Ubuntu version
 ubuntu="$(lsb_release -a | sed -n 2p | awk '{print $3, $4}')"
-if [ ! "$ubuntu" = "24.04.3 LTS" ]
+if [ ! "$ubuntu" = "24.04.4 LTS" ]
 then
 ubuntu="\Zb\Z1$(lsb_release -a | sed -n 2p | awk '{print $3, $4}')\Zn"
 fi
@@ -219,7 +219,7 @@ Disk size: $disksz        $DiskUsedPercent used \n\
 Ubuntu: $ubuntu \n\
 HTTP & HTTPS:  $http \n\
 ------------------------------------------ \n\
-Google Cloud Nightscout  2026.01.06\n\
+Google Cloud Nightscout  2026.02.21\n\
 $apisec_problem $Missing $Phase1 $rclocal_1 $freedns_id_pass \n\n\
 /$uname/$repo/$branch\n\
 Swap: $swap \n\

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -108,7 +108,7 @@ sudo git clone https://github.com/jamorham/nightscout-vps.git  # ✅✅✅✅✅
 ls > /tmp/repo
 sudo mv -f /tmp/repo .    # The repository name is now in /srv/repo
 cd "$(< repo)"
-sudo git checkout vps-dev  # ✅✅✅✅✅ Main - Uncomment before PR.
+sudo git checkout vps-2  # ✅✅✅✅✅ Main - Uncomment before PR.
 #sudo git checkout SmallWindowWarning_Test  # ⛔⛔⛔⛔⛔ For test - Comment out before PR.
 
 sudo git branch > /tmp/branch

--- a/update_packages.sh
+++ b/update_packages.sh
@@ -13,7 +13,7 @@ sudo apt-get update
 
 #Ubuntu upgrade available
 NextUbuntu="$(apt-get -s upgrade | grep 'Inst base' | awk '{print $4}' | sed 's/(//')"
-if [ "$NextUbuntu" = "13ubuntu10.3" ] # Only upgrade if we have tested the next release (24.04.3)
+if [ "$NextUbuntu" = "13ubuntu10.4" ] # Only upgrade if we have tested the next release (24.04.4)
 then
   sudo apt-get -y upgrade
 fi


### PR DESCRIPTION
I have been using our dev branch for a few days and see no issue.
The only change is that the latest Ubuntu 24 version becomes acceptable and not highlighted in red on the status page, and our update utility will upgrade an existing Ubuntu 24 install to 24.04.4.