### PR TITLE
Verify node_modules directory on status page

### DIFF
--- a/Status.sh
+++ b/Status.sh
@@ -128,13 +128,15 @@ then
 fi
 
 # Verify that Installation phase 1 has been executed after bootstrap
+# Bootstrap clears the /srv directory.  It then creates a local clone of the repository, which recreates the node_modules directory.
+# But, this directory will only contain a .cache directory until phase is run.  That's how we verify if phase 1 has been executed after or not.
 Phase1=""
 cd /srv
 cd "$(< repo)"
-if [ ! -s ./node_modules ]
+if [ "$(ls -A node_modules | grep -v '^\.cache$' | wc -l)" -eq 0 ]
 then
   Phase1="\Zb\Z1Missing node_modules\Zn"
-fi  
+fi 
 
 # Verify that exit 0 is in rc.local so that Nightscout can start after a reboot even if FreeDNS is down.
 rclocal_1="\Zb\Z1Startup dependence on FreeDNS\Zn"
@@ -219,7 +221,7 @@ Disk size: $disksz        $DiskUsedPercent used \n\
 Ubuntu: $ubuntu \n\
 HTTP & HTTPS:  $http \n\
 ------------------------------------------ \n\
-Google Cloud Nightscout  2026.03.21\n\
+Google Cloud Nightscout  2026.03.22\n\
 $apisec_problem $Missing $Phase1 $rclocal_1 $freedns_id_pass \n\n\
 /$uname/$repo/$branch\n\
 Swap: $swap \n\

--- a/Status.sh
+++ b/Status.sh
@@ -129,7 +129,7 @@ fi
 
 # Verify that Installation phase 1 has been executed after bootstrap
 # Bootstrap clears the /srv directory.  It then creates a local clone of the repository, which recreates the node_modules directory.
-# But, this directory will only contain a .cache directory until phase is run.  That's how we verify if phase 1 has been executed after or not.
+# But, this directory will only contain a .cache directory until phase 1 is run.  That's how we verify if phase 1 has been executed after or not.
 Phase1=""
 cd /srv
 cd "$(< repo)"


### PR DESCRIPTION
This PR fixes how we detect if the node_modules directory has been fully recreated or not.  

To test this, I created a fully functional Nightscout witt my test:
<img width="388" height="469" alt="Screenshot 2026-03-22 095807" src="https://github.com/user-attachments/assets/e34687f7-43e0-4fe1-8f02-7bb163e08fe4" />

Then, I intentionally ran bootstrap from the same branch again.  This clears the srv directory.   And it should make the status page highlight it.
After just running bootstrap, the status page did not change the Nightscout site remained functional.  But, after restarting the server, Nightscout stopped working and this is what the status page showed:
<img width="382" height="469" alt="Screenshot 2026-03-22 100151" src="https://github.com/user-attachments/assets/95b11bfd-c7ef-4f77-9159-2f70d033ecda" />
 
It shows missing node modules in red.

And after running Phase 1 everything works again and status page is back to normal again.  