### PR TITLE
Idempotent phase 1 and phase 2 

### DIFF
--- a/Status.sh
+++ b/Status.sh
@@ -221,7 +221,7 @@ Disk size: $disksz        $DiskUsedPercent used \n\
 Ubuntu: $ubuntu \n\
 HTTP & HTTPS:  $http \n\
 ------------------------------------------ \n\
-Google Cloud Nightscout  2026.04.30\n\
+Google Cloud Nightscout  2026.05.10\n\
 $apisec_problem $Missing $Phase1 $rclocal_1 $freedns_id_pass \n\n\
 /$uname/$repo/$branch\n\
 Swap: $swap \n\

--- a/update_packages.sh
+++ b/update_packages.sh
@@ -19,13 +19,9 @@ then
 fi
 
 # packages
-whichpack=$(which gpg)
-if [ "$whichpack" = "" ]
-then
-  /xDrip/scripts/wait_4_completion.sh
-  sudo apt-get -y install jq net-tools gnupg
-  # The last item on the above list of packages must be verified in Status.sh to have been installed.
-fi 
+/xDrip/scripts/wait_4_completion.sh
+sudo apt-get -y install jq net-tools gnupg
+# The last item on the above list of packages must be verified in Status.sh to have been installed.
 
 
 # mongo

--- a/update_packages2.sh
+++ b/update_packages2.sh
@@ -7,20 +7,16 @@ echo
 # Let's upgrade packages if available and install the missing needed packages.
 
 # packages
-whichpack=$(which file)
-if [ "$whichpack" = "" ]
-then
-  /xDrip/scripts/wait_4_completion.sh
-  sudo apt-get update
-  /xDrip/scripts/wait_4_completion.sh
-  sudo apt-get -y install screen nano qrencode file vis lsb-release apt-transport-https ca-certificates python3-pip bind9-dnsutils nginx python3-certbot-nginx inetutils-ping 
-  /xDrip/scripts/wait_4_completion.sh
-  sudo apt -y install python3-django python3-django-extensions python3-werkzeug python3-qrcode
-fi 
+/xDrip/scripts/wait_4_completion.sh
+sudo apt-get update
+/xDrip/scripts/wait_4_completion.sh
+sudo apt-get -y install screen nano qrencode file vis lsb-release apt-transport-https ca-certificates python3-pip bind9-dnsutils nginx python3-certbot-nginx inetutils-ping 
+/xDrip/scripts/wait_4_completion.sh
+sudo apt -y install python3-django python3-django-extensions python3-werkzeug python3-qrcode
 
 # The last item on the above list of packages must be verified in Status.sh to have been installed.  
 
 # Add log
 /xDrip/scripts/AddLog.sh "The secondary packages have been installed" /xDrip/Logs
-
+  
   


### PR DESCRIPTION
If any of the packages that are meant to be installed by phase1 or phase 2 are not installed for any reason, rerunning phase 1 or phase 2 again will never install them.  This is because of the conditionals I added a long time ago to reduce the install time.
But, there is a negative consequence to them if something goes wrong and all the packages are not installed the first time phase 1 or phase 2 is executed.

This PR removes the conditionals.  Therefore, running phase 1 or phase 2 installs them all again.  But, the Linux package installer will only go ahead with the install if the package is not already installed.  Therefor, there is no negative side-effect to removing those conditionals.